### PR TITLE
Added pipe diameter data defined rendering

### DIFF
--- a/README
+++ b/README
@@ -34,10 +34,17 @@ Assuming you named your database qwat, edit the ~/.pg_service.conf file and make
  #you can also add your password if you like
  password=YourPassword
 
-Now go to the 'data-model' directory and run the 'create_schemas.bash' script:
+Now go to the 'data-model' directory and run the './init_qwat.sh' script:
 
  cd data-model
- ./create_schemas.bash
+ ./init_qwat.sh -p qwat -s 21781 -d -r
+ 
+The script has the following options:
+
+ -p                   PG service to connect to the database.
+ -s or --srid         PostGIS SRID. Default to 21781 (ch1903)
+ -d or --drop-schema  drop schemas (cascaded) if they exist
+ -r or --create-roles create roles in the database
 
 After your model gets created, in QGIS you should now be able to connect to the database by creating a new connection with Name=qwat, Service=qwat, SSL mode=prefer.
 

--- a/qgis-project/qwat.qgs
+++ b/qgis-project/qwat.qgs
@@ -26461,6 +26461,7 @@
             <field name="value_ro"/>
             <field name="_displayname_ro"/>
             <field name="diameter"/>
+            <field name="diameter_external"/>
             <field name="diameter_nominal"/>
           </joinFieldsSubset>
         </join>

--- a/qgis-project/qwat.qgs
+++ b/qgis-project/qwat.qgs
@@ -26736,6 +26736,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -26763,6 +26767,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="1"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -26790,6 +26798,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 1.2&#xa;ELSE 1.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -26817,6 +26829,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -26844,6 +26860,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="1"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -26871,6 +26891,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 1.2&#xa;ELSE 1.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -26898,6 +26922,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -26925,6 +26953,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="1"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -26952,6 +26984,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 1.2&#xa;ELSE 1.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -26979,6 +27015,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -27006,6 +27046,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="1"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -27033,6 +27077,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 1.2&#xa;ELSE 1.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -27060,6 +27108,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 1.2&#xa;ELSE 1.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -27188,6 +27240,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -27215,6 +27271,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="1"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -27242,6 +27302,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 1.2&#xa;ELSE 1.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -27269,6 +27333,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -27296,6 +27364,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="0"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
@@ -27323,6 +27395,10 @@
               <prop k="offset_map_unit_scale" v="0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="use_custom_dash" v="1"/>
+              <prop k="width_dd_active" v="1"/>
+              <prop k="width_dd_expression" v="CASE WHEN &quot;pipe_material_diameter&quot; is not NULL&#xa;THEN toreal(COALESCE(&quot;pipe_material_diameter_external&quot;,&quot;pipe_material_diameter_nominal&quot;)) / 900 + 0.2&#xa;ELSE 0.2&#xa;END"/>
+              <prop k="width_dd_field" v=""/>
+              <prop k="width_dd_useexpr" v="1"/>
               <prop k="width_map_unit_scale" v="0,0"/>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">


### PR DESCRIPTION
Hi,

I didn't do it for the "chemisée" styling as I wasn't able to see your styling (how you envisioned it) so I left it untouched.
Also, I didn't know if you wanted this option for "Couleur par zone" option so I also left it untouched.

As the diameter column is a string and sometimes it's also in inches, it should be skipped so I settled on:
CASE WHEN "pipe_material_diameter" is not NULL
THEN toreal(COALESCE("pipe_material_diameter_external","pipe_material_diameter_nominal")) / 900 + 0.2
ELSE 0.2
END

For the "Protejee" ones, I added +1 width to the formula.

Tell me if you want it different.
Regards

PS. this will work well in conjuction with https://github.com/qwat/qwat-data-model/pull/55