### PR TITLE
fix reservoir duplicate labels 'Rés. incendie'

### DIFF
--- a/qgis-project/ui_forms/installation.ui
+++ b/qgis-project/ui_forms/installation.ui
@@ -659,7 +659,7 @@
        <item row="3" column="4">
         <widget class="QLabel" name="label_38">
          <property name="text">
-          <string>Rés. incendie</string>
+          <string>Type rés. incendie</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/3179646/10119822/12a954b2-64ab-11e5-8e14-d9214b1a21de.png)

After:
![after](https://cloud.githubusercontent.com/assets/3179646/10119825/1e788bdc-64ab-11e5-9f45-ca2288576228.png)

