### PR TITLE
added open_water_surface label to installation form

### DIFF
--- a/qgis-project/ui_forms/installation.ui
+++ b/qgis-project/ui_forms/installation.ui
@@ -37,6 +37,16 @@
        <string>Général</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="id">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="3">
         <widget class="QComboBox" name="installation_type">
          <property name="enabled">
@@ -104,16 +114,6 @@
         <widget class="QLabel" name="label_11">
          <property name="text">
           <string>Distributeur</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLineEdit" name="id">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -194,6 +194,13 @@
        <item row="4" column="3">
         <widget class="QLineEdit" name="parcel"/>
        </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="label_53">
+         <property name="text">
+          <string>Type</string>
+         </property>
+        </widget>
+       </item>
        <item row="2" column="1">
         <widget class="QgsRelationReferenceWidget" name="fk_parent"/>
        </item>
@@ -204,10 +211,13 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="label_53">
+       <item row="8" column="3">
+        <widget class="QCheckBox" name="open_water_surface">
          <property name="text">
-          <string>Type</string>
+          <string>Eau de surface</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
I've labeled it `Eau de surface`, please say if you want it otherwise:

![pic](https://cloud.githubusercontent.com/assets/3179646/10121692/8b728674-6501-11e5-92b3-13dd437f74ef.png)
