### PR TITLE
renamed Acces --> Emplacement + fix typo

### DIFF
--- a/qgis-project/qwat.qgs
+++ b/qgis-project/qwat.qgs
@@ -180,7 +180,7 @@
     </layer-tree-group>
     <layer-tree-group expanded="0" checked="Qt::PartiallyChecked" name="Tables auxiliaires">
       <customproperties/>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="locationtype20150922082741813" name="accès">
+      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="locationtype20150922082741813" name="emplacement">
         <customproperties/>
       </layer-tree-layer>
       <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_subscriber_type20130304110011480" name="abonnés - type">

--- a/qgis-project/ui_forms/installation.ui
+++ b/qgis-project/ui_forms/installation.ui
@@ -456,19 +456,15 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
-       <widget class="QgsDateTimeEdit" name="mDateTimeEdit">
-        <property name="calendarPopup">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
       <item row="6" column="0">
        <widget class="QCheckBox" name="gathering_chamber">
         <property name="text">
          <string>chambre de rassemblement</string>
         </property>
        </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QDateEdit" name="contract_end"/>
       </item>
      </layout>
     </widget>
@@ -881,11 +877,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>QgsDateTimeEdit</class>
-   <extends>QDateTimeEdit</extends>
-   <header>qgsdatetimeedit.h</header>
-  </customwidget>
   <customwidget>
    <class>QgsRelationReferenceWidget</class>
    <extends>QWidget</extends>

--- a/qgis-project/ui_forms/installation.ui
+++ b/qgis-project/ui_forms/installation.ui
@@ -225,11 +225,11 @@
      </widget>
      <widget class="QWidget" name="tab_2">
       <attribute name="title">
-       <string>Accès</string>
+       <string>Emplacement</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
        <item row="0" column="0">
-        <widget class="QListWidget" name="fk_location_type"/>
+        <widget class="QListWidget" name="fk_locationtype"/>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
Fixes https://github.com/qwat/QWAT/issues/41

For consistency sake and to avoid future typos, do you think we should maybe rework some of the database columns and table names that have concatenated words so that there's always a `_` between them?

E.g. 
- fk_locationtype --> fk_location_type
- precisionalti --> precision_alti
etc.

A simple find and replace in the project, ui's and database model creation script should do it.