### PR TITLE
Fix for installation parts

### DIFF
--- a/qgis-project/qwat.qgs
+++ b/qgis-project/qwat.qgs
@@ -42361,8 +42361,8 @@
         <edittype widgetv2type="TextEdit" name="label_2_text">
           <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
         </edittype>
-        <edittype widgetv2type="TextEdit" name="fk_part_type">
-          <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
+        <edittype widgetv2type="ValueRelation" name="fk_part_type">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" Layer="vl_part_type20140429114640509" Value="value_fr" labelOnTop="0" AllowMulti="0"/>
         </edittype>
         <edittype widgetv2type="TextEdit" name="fk_pipe">
           <widgetv2config IsMultiline="0" fieldEditable="0" UseHtml="0" labelOnTop="0"/>


### PR DESCRIPTION
fixed part_type value relation

Hi again, I have a question about the `compteur` value in the installation parts layer.
Is it referring to a flow meter or to a water meter?
If it's referring to a flow meter than please don't merge as I want to rebase and change the styling name from `compteur` to `débitmètre`.

Thanks!