### PR TITLE
Project improvements (remove duplicate Reseau group, add ouvrages_polygon, consistent lyr_names)

### DIFF
--- a/qgis-project/qwat.qgs
+++ b/qgis-project/qwat.qgs
@@ -29,6 +29,9 @@
             <property key="showFeatureCount" value="1"/>
           </customproperties>
         </layer-tree-layer>
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="vw_element_installation20170706152829679" source="service='qwat' sslmode=disable key='id' srid=21781 type=MultiPolygon table=&quot;qwat_od&quot;.&quot;vw_element_installation&quot; (geometry_polygon) sql=" name="ouvrage_polygon">
+          <customproperties/>
+        </layer-tree-layer>
         <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="od_cover20141219115626229" source="service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;cover&quot; (geometry) sql=" name="couvercles">
           <customproperties>
             <property key="showFeatureCount" value="1"/>
@@ -397,9 +400,9 @@
   <mapcanvas>
     <units>meters</units>
     <extent>
-      <xmin>515558.26681433472549543</xmin>
+      <xmin>515374.7496262900531292</xmin>
       <ymin>157704.20343968755332753</ymin>
-      <xmax>515764.64283714181510732</xmax>
+      <xmax>515948.16002518648747355</xmax>
       <ymax>157868.03498222940834239</ymax>
     </extent>
     <rotation>0</rotation>
@@ -454,6 +457,7 @@
       <layer_coordinate_transform destAuthId="EPSG:21781" srcAuthId="EPSG:21781" srcDatumTransform="-1" destDatumTransform="-1" layerid="installation_chamber20131107105006707"/>
       <layer_coordinate_transform destAuthId="EPSG:21781" srcAuthId="EPSG:21781" srcDatumTransform="-1" destDatumTransform="-1" layerid="riviera20130902113350360"/>
       <layer_coordinate_transform destAuthId="EPSG:21781" srcAuthId="EPSG:21781" srcDatumTransform="-1" destDatumTransform="-1" layerid="od_remote20150116100522170"/>
+      <layer_coordinate_transform destAuthId="EPSG:21781" srcAuthId="EPSG:21781" srcDatumTransform="-1" destDatumTransform="-1" layerid="vw_element_installation20170706152829679"/>
       <layer_coordinate_transform destAuthId="EPSG:21781" srcAuthId="EPSG:21781" srcDatumTransform="-1" destDatumTransform="-1" layerid="pressurezone20130417133612105"/>
       <layer_coordinate_transform destAuthId="EPSG:21781" srcAuthId="EPSG:21781" srcDatumTransform="-1" destDatumTransform="-1" layerid="od_valve20141218090331728"/>
       <layer_coordinate_transform destAuthId="EPSG:21781" srcAuthId="EPSG:21781" srcDatumTransform="-1" destDatumTransform="-1" layerid="nom_rue20160215151152641"/>
@@ -599,6 +603,7 @@
       <item>hydrant_output20160205143014497</item>
       <item>SWISSIMAGE20161031083131993</item>
       <item>vw_pipe_schema20170306143352379179081243</item>
+      <item>vw_element_installation20170706152829679</item>
     </custom-order>
   </layer-tree-canvas>
   <legend updateDrawingOrder="false">
@@ -607,6 +612,11 @@
         <legendlayer drawingOrder="1" open="false" checked="Qt::Checked" name="ouvrage" showFeatureCount="1">
           <filegroup open="false" hidden="false">
             <legendlayerfile isInOverview="0" layerid="vw_node_installation20150918153835436" visible="1"/>
+          </filegroup>
+        </legendlayer>
+        <legendlayer drawingOrder="76" open="true" checked="Qt::Checked" name="ouvrage_polygon" showFeatureCount="0">
+          <filegroup open="true" hidden="false">
+            <legendlayerfile isInOverview="0" layerid="vw_element_installation20170706152829679" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="0" open="true" checked="Qt::Unchecked" name="couvercles" showFeatureCount="1">
@@ -45340,6 +45350,938 @@ def my_form_open(dialog, layer, feature):
         <default field="_sum_subscriber" expression=""/>
       </defaults>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
+    </maplayer>
+    <maplayer simplifyAlgorithm="0" minimumScale="100000" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+      <extent>
+        <xmin>515581.16486522898776457</xmin>
+        <ymin>157770.85384369498933665</ymin>
+        <xmax>515687.43530656100483611</xmax>
+        <ymax>157841.60294966498622671</ymax>
+      </extent>
+      <id>vw_element_installation20170706152829679</id>
+      <datasource>service='qwat' sslmode=disable key='id' srid=21781 type=MultiPolygon table="qwat_od"."vw_element_installation" (geometry_polygon) sql=</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>ouvrage_polygon</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
+          <srsid>1919</srsid>
+          <srid>21781</srid>
+          <authid>EPSG:21781</authid>
+          <description>CH1903 / LV03</description>
+          <projectionacronym>somerc</projectionacronym>
+          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <provider encoding="System">postgres</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="">
+        <map-layer-style name=""/>
+      </map-layer-style-manager>
+      <edittypes>
+        <edittype widgetv2type="TextEdit" name="id">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_district">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="0" Key="id" constraint="" Layer="district20130304110004764" Value="name" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_pressurezone">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="pressurezone20130417133612105" Value="name" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="fk_printmap">
+          <widgetv2config IsMultiline="0" fieldEditable="0" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="_printmaps">
+          <widgetv2config IsMultiline="0" fieldEditable="0" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="_geometry_alt1_used">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="_geometry_alt2_used">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="_pipe_node_type">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="_pipe_orientation">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="_pipe_schema_visible">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="geometry">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="geometry_alt1">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="geometry_alt2">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="update_geometry_alt1">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="update_geometry_alt2">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="identification">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_distributor">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="distributor20130304114719702" Value="name" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_status">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="vl_status20130304110011436" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="fk_folder">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_locationtype">
+          <widgetv2config OrderByValue="0" AllowNull="1" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="locationtype20150922082741813" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="1" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_precision">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="vl_precision20130304110011372" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_precisionalti">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="vl_precisionalti20131211161429510" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_object_reference">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="object_reference20150922083109152" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="altitude">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="year">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="year_end">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="orientation">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="remark">
+          <widgetv2config IsMultiline="1" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="schema_force_visible">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="label_1_visible">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="label_1_x">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="label_1_y">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="label_1_rotation">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="label_1_text">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="label_2_visible">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="label_2_x">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="label_2_y">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="label_2_rotation">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="label_2_text">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueMap" name="installation_type">
+          <widgetv2config fieldEditable="1" constraint="" labelOnTop="0" constraintDescription="" notNull="0">
+            <value key="chambre" value="chamber"/>
+            <value key="pompage" value="pump"/>
+            <value key="régulation de pression" value="pressurecontrol"/>
+            <value key="réservoir" value="tank"/>
+            <value key="source" value="source"/>
+            <value key="traitement" value="treatment"/>
+          </widgetv2config>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="name">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="RelationReference" name="fk_parent">
+          <widgetv2config OrderByValue="0" fieldEditable="1" AllowAddFeatures="0" ShowForm="0" Relation="relation_installation_parent" ReadOnly="0" constraint="" MapIdentification="1" labelOnTop="0" constraintDescription="" notNull="0" AllowNULL="1"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_remote">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="remote_type20130304110004987" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_watertype">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="vl_watertype20131217141603877" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="parcel">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="eca">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="open_water_surface">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_source_type">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="vl_sourcetype20130820110518791" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_source_quality">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="vl_sourcequality20130820110518810" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="flow_lowest">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="flow_average">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="flow_concession">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="DateTime" name="contract_end">
+          <widgetv2config fieldEditable="1" calendar_popup="1" allow_null="1" display_format="yyyy-MM-dd" field_format="yyyy-MM-dd" constraint="" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="gathering_chamber">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_pump_type">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="vl_pumptype20130816140237776" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="RelationReference" name="fk_pipe_in">
+          <widgetv2config OrderByValue="0" fieldEditable="1" AllowAddFeatures="0" ShowForm="0" Relation="relation_pump_pipe_in" ReadOnly="1" constraint="" MapIdentification="1" labelOnTop="0" constraintDescription="" notNull="0" AllowNULL="1"/>
+        </edittype>
+        <edittype widgetv2type="RelationReference" name="fk_pipe_out">
+          <widgetv2config OrderByValue="0" fieldEditable="1" AllowAddFeatures="0" ShowForm="0" Relation="relation_pump_pipe_out" ReadOnly="1" constraint="" MapIdentification="1" labelOnTop="0" constraintDescription="" notNull="0" AllowNULL="1"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_pump_operating">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="pump_operating20150922083814587" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="Range" name="no_pumps">
+          <widgetv2config AllowNull="1" fieldEditable="1" Step="1" constraint="" Style="SpinBox" labelOnTop="0" constraintDescription="" Min="0" notNull="0" Max="99"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="rejected_flow">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="manometric_height">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_overflow">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="vl_overflow20130304170704046" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_tank_firestorage">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="vl_tank_firestorage20130304170704030" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="storage_total">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="storage_supply">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="storage_fire">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="altitude_overflow">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="altitude_apron">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="height_max">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="fire_valve">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="fire_remote">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="_litrepercm">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="cistern1_fk_type">
+          <widgetv2config OrderByValue="0" AllowNull="1" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="vl_cistern20130304110005061" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="cistern1_dimension_1">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="cistern1_dimension_2">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="cistern1_storage">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="_cistern1_litrepercm">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="cistern2_fk_type">
+          <widgetv2config OrderByValue="0" AllowNull="1" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="vl_cistern20130304110005061" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="cistern2_dimension_1">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="cistern2_dimension_2">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="cistern2_storage">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="_cistern2_litrepercm">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="sanitization_uv">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="sanitization_chlorine_liquid">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="sanitization_chlorine_gazeous">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="sanitization_ozone">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="filtration_membrane">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="filtration_sandorgravel">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="flocculation">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="activatedcharcoal">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="settling">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="treatment_capacity">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="networkseparation">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="flow_meter">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="water_meter">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="CheckBox" name="manometer">
+          <widgetv2config fieldEditable="1" UncheckedState="f" constraint="" CheckedState="t" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="depth">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="Range" name="no_valves">
+          <widgetv2config AllowNull="1" fieldEditable="1" Step="1" constraint="" Style="SpinBox" labelOnTop="0" constraintDescription="" Min="0" notNull="0" Max="99"/>
+        </edittype>
+        <edittype widgetv2type="ValueRelation" name="fk_pressurecontrol_type">
+          <widgetv2config OrderByValue="0" AllowNull="0" FilterExpression="" UseCompleter="0" fieldEditable="1" Key="id" constraint="" Layer="pressurecontrol_type20150203100321270" Value="value_fr" labelOnTop="0" constraintDescription="" AllowMulti="0" notNull="0"/>
+        </edittype>
+      </edittypes>
+      <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" type="fill" name="0">
+            <layer pass="0" class="GradientFill" locked="0">
+              <prop k="angle" v="0"/>
+              <prop k="color" v="0,213,255,187"/>
+              <prop k="color1" v="0,0,255,255"/>
+              <prop k="color2" v="0,255,0,255"/>
+              <prop k="color_type" v="0"/>
+              <prop k="coordinate_mode" v="0"/>
+              <prop k="discrete" v="0"/>
+              <prop k="gradient_color2" v="255,255,255,255"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="reference_point1" v="0,0"/>
+              <prop k="reference_point1_iscentroid" v="0"/>
+              <prop k="reference_point2" v="1,1"/>
+              <prop k="reference_point2_iscentroid" v="0"/>
+              <prop k="spread" v="0"/>
+              <prop k="type" v="1"/>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale scalemethod="diameter"/>
+      </renderer-v2>
+      <labeling type="simple"/>
+      <customproperties>
+        <property key="embeddedWidgets/count" value="0"/>
+        <property key="labeling" value="pal"/>
+        <property key="labeling/addDirectionSymbol" value="false"/>
+        <property key="labeling/angleOffset" value="0"/>
+        <property key="labeling/blendMode" value="0"/>
+        <property key="labeling/bufferBlendMode" value="0"/>
+        <property key="labeling/bufferColorA" value="255"/>
+        <property key="labeling/bufferColorB" value="255"/>
+        <property key="labeling/bufferColorG" value="255"/>
+        <property key="labeling/bufferColorR" value="255"/>
+        <property key="labeling/bufferDraw" value="true"/>
+        <property key="labeling/bufferJoinStyle" value="64"/>
+        <property key="labeling/bufferNoFill" value="false"/>
+        <property key="labeling/bufferSize" value="1"/>
+        <property key="labeling/bufferSizeInMapUnits" value="false"/>
+        <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
+        <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
+        <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/bufferTransp" value="0"/>
+        <property key="labeling/centroidInside" value="false"/>
+        <property key="labeling/centroidWhole" value="false"/>
+        <property key="labeling/dataDefined/PositionX" value="0~~0~~~~label_1_x"/>
+        <property key="labeling/dataDefined/PositionY" value="0~~0~~~~label_1_y"/>
+        <property key="labeling/dataDefined/Rotation" value="0~~0~~~~label_1_rotation"/>
+        <property key="labeling/decimals" value="3"/>
+        <property key="labeling/displayAll" value="true"/>
+        <property key="labeling/dist" value="3"/>
+        <property key="labeling/distInMapUnits" value="false"/>
+        <property key="labeling/distMapUnitMaxScale" value="0"/>
+        <property key="labeling/distMapUnitMinScale" value="0"/>
+        <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/drawLabels" value="false"/>
+        <property key="labeling/enabled" value="false"/>
+        <property key="labeling/fieldName" value="CASE&#xa;WHEN  &quot;installation_type&quot;  = 'chamber' THEN 'C. '&#xa;WHEN &quot;installation_type&quot;  = 'pressurecontrol' AND fk_pressurecontrol_type = 2801 THEN 'CR. '&#xa;WHEN  &quot;installation_type&quot;  = 'pressurecontrol' AND fk_pressurecontrol_type = 2802 THEN 'CCP. ' &#xa;WHEN  &quot;installation_type&quot;  = 'pressurecontrol' AND fk_pressurecontrol_type = 2803 THEN 'CRA. '&#xa;WHEN  &quot;installation_type&quot;  = 'pump' THEN 'P. ' &#xa;WHEN  &quot;installation_type&quot;  = 'source' THEN 'S. ' &#xa;WHEN  &quot;installation_type&quot;  = 'tank' THEN 'R. '&#xa;WHEN  &quot;installation_type&quot;  = 'treatment' THEN 'T. '&#xa;ELSE '' &#xa;END&#xa;|| coalesce(name, '')"/>
+        <property key="labeling/fitInPolygonOnly" value="false"/>
+        <property key="labeling/fontBold" value="false"/>
+        <property key="labeling/fontCapitals" value="0"/>
+        <property key="labeling/fontFamily" value="Lato"/>
+        <property key="labeling/fontItalic" value="false"/>
+        <property key="labeling/fontLetterSpacing" value="0"/>
+        <property key="labeling/fontLimitPixelSize" value="false"/>
+        <property key="labeling/fontMaxPixelSize" value="10000"/>
+        <property key="labeling/fontMinPixelSize" value="3"/>
+        <property key="labeling/fontSize" value="11"/>
+        <property key="labeling/fontSizeInMapUnits" value="false"/>
+        <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
+        <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
+        <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/fontStrikeout" value="false"/>
+        <property key="labeling/fontUnderline" value="false"/>
+        <property key="labeling/fontWeight" value="50"/>
+        <property key="labeling/fontWordSpacing" value="0"/>
+        <property key="labeling/formatNumbers" value="false"/>
+        <property key="labeling/isExpression" value="true"/>
+        <property key="labeling/labelOffsetInMapUnits" value="true"/>
+        <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
+        <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
+        <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/labelPerPart" value="false"/>
+        <property key="labeling/leftDirectionSymbol" value="&lt;"/>
+        <property key="labeling/limitNumLabels" value="false"/>
+        <property key="labeling/maxCurvedCharAngleIn" value="20"/>
+        <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
+        <property key="labeling/maxNumLabels" value="2000"/>
+        <property key="labeling/mergeLines" value="false"/>
+        <property key="labeling/minFeatureSize" value="0"/>
+        <property key="labeling/multilineAlign" value="1"/>
+        <property key="labeling/multilineHeight" value="1"/>
+        <property key="labeling/namedStyle" value="Regular"/>
+        <property key="labeling/obstacle" value="true"/>
+        <property key="labeling/obstacleFactor" value="1"/>
+        <property key="labeling/obstacleType" value="0"/>
+        <property key="labeling/offsetType" value="0"/>
+        <property key="labeling/placeDirectionSymbol" value="0"/>
+        <property key="labeling/placement" value="0"/>
+        <property key="labeling/placementFlags" value="10"/>
+        <property key="labeling/plussign" value="false"/>
+        <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
+        <property key="labeling/preserveRotation" value="true"/>
+        <property key="labeling/previewBkgrdColor" value="#ffffff"/>
+        <property key="labeling/priority" value="5"/>
+        <property key="labeling/quadOffset" value="4"/>
+        <property key="labeling/repeatDistance" value="0"/>
+        <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
+        <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
+        <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/repeatDistanceUnit" value="1"/>
+        <property key="labeling/reverseDirectionSymbol" value="false"/>
+        <property key="labeling/rightDirectionSymbol" value=">"/>
+        <property key="labeling/scaleMax" value="10000000"/>
+        <property key="labeling/scaleMin" value="1"/>
+        <property key="labeling/scaleVisibility" value="false"/>
+        <property key="labeling/shadowBlendMode" value="6"/>
+        <property key="labeling/shadowColorB" value="0"/>
+        <property key="labeling/shadowColorG" value="0"/>
+        <property key="labeling/shadowColorR" value="0"/>
+        <property key="labeling/shadowDraw" value="false"/>
+        <property key="labeling/shadowOffsetAngle" value="135"/>
+        <property key="labeling/shadowOffsetDist" value="1"/>
+        <property key="labeling/shadowOffsetGlobal" value="true"/>
+        <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
+        <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
+        <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shadowOffsetUnits" value="1"/>
+        <property key="labeling/shadowRadius" value="1.5"/>
+        <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
+        <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
+        <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
+        <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shadowRadiusUnits" value="1"/>
+        <property key="labeling/shadowScale" value="100"/>
+        <property key="labeling/shadowTransparency" value="30"/>
+        <property key="labeling/shadowUnder" value="0"/>
+        <property key="labeling/shapeBlendMode" value="0"/>
+        <property key="labeling/shapeBorderColorA" value="255"/>
+        <property key="labeling/shapeBorderColorB" value="128"/>
+        <property key="labeling/shapeBorderColorG" value="128"/>
+        <property key="labeling/shapeBorderColorR" value="128"/>
+        <property key="labeling/shapeBorderWidth" value="0"/>
+        <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
+        <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
+        <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shapeBorderWidthUnits" value="1"/>
+        <property key="labeling/shapeDraw" value="false"/>
+        <property key="labeling/shapeFillColorA" value="255"/>
+        <property key="labeling/shapeFillColorB" value="255"/>
+        <property key="labeling/shapeFillColorG" value="255"/>
+        <property key="labeling/shapeFillColorR" value="255"/>
+        <property key="labeling/shapeJoinStyle" value="64"/>
+        <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
+        <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
+        <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shapeOffsetUnits" value="1"/>
+        <property key="labeling/shapeOffsetX" value="0"/>
+        <property key="labeling/shapeOffsetY" value="0"/>
+        <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
+        <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
+        <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shapeRadiiUnits" value="1"/>
+        <property key="labeling/shapeRadiiX" value="0"/>
+        <property key="labeling/shapeRadiiY" value="0"/>
+        <property key="labeling/shapeRotation" value="0"/>
+        <property key="labeling/shapeRotationType" value="0"/>
+        <property key="labeling/shapeSVGFile" value=""/>
+        <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
+        <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
+        <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
+        <property key="labeling/shapeSizeType" value="0"/>
+        <property key="labeling/shapeSizeUnits" value="1"/>
+        <property key="labeling/shapeSizeX" value="0"/>
+        <property key="labeling/shapeSizeY" value="0"/>
+        <property key="labeling/shapeTransparency" value="0"/>
+        <property key="labeling/shapeType" value="0"/>
+        <property key="labeling/substitutions" value="&lt;substitutions/>"/>
+        <property key="labeling/textColorA" value="255"/>
+        <property key="labeling/textColorB" value="0"/>
+        <property key="labeling/textColorG" value="0"/>
+        <property key="labeling/textColorR" value="0"/>
+        <property key="labeling/textTransp" value="0"/>
+        <property key="labeling/upsidedownLabels" value="0"/>
+        <property key="labeling/useSubstitutions" value="false"/>
+        <property key="labeling/wrapChar" value=""/>
+        <property key="labeling/xOffset" value="0"/>
+        <property key="labeling/yOffset" value="0"/>
+        <property key="labeling/zIndex" value="0"/>
+        <property key="variableNames"/>
+        <property key="variableValues"/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerTransparency>0</layerTransparency>
+      <displayfield>name</displayfield>
+      <label>0</label>
+      <labelattributes>
+        <label fieldname="" text="Label"/>
+        <family fieldname="" name="Cantarell"/>
+        <size fieldname="" units="pt" value="12"/>
+        <bold fieldname="" on="0"/>
+        <italic fieldname="" on="0"/>
+        <underline fieldname="" on="0"/>
+        <strikeout fieldname="" on="0"/>
+        <color fieldname="" red="0" blue="0" green="0"/>
+        <x fieldname=""/>
+        <y fieldname=""/>
+        <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
+        <angle fieldname="" value="0" auto="0"/>
+        <alignment fieldname="" value="center"/>
+        <buffercolor fieldname="" red="255" blue="255" green="255"/>
+        <buffersize fieldname="" units="pt" value="1"/>
+        <bufferenabled fieldname="" on=""/>
+        <multilineenabled fieldname="" on=""/>
+        <selectedonly on=""/>
+      </labelattributes>
+      <SingleCategoryDiagramRenderer diagramType="Pie" sizeLegend="0" attributeLegend="1">
+        <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="100000">
+          <fontProperties description="Cantarell,11,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
+        </DiagramCategory>
+        <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
+          <layer pass="0" class="SimpleMarker" locked="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="255,0,0,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="circle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="0,0,0,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0"/>
+            <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="2"/>
+            <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+          </layer>
+        </symbol>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings yPosColumn="-1" showColumn="0" linePlacementFlags="10" placement="0" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
+      <annotationform>.</annotationform>
+      <aliases>
+        <alias field="id" index="0" name=""/>
+        <alias field="fk_district" index="1" name=""/>
+        <alias field="fk_pressurezone" index="2" name=""/>
+        <alias field="fk_printmap" index="3" name=""/>
+        <alias field="_printmaps" index="4" name=""/>
+        <alias field="_geometry_alt1_used" index="5" name=""/>
+        <alias field="_geometry_alt2_used" index="6" name=""/>
+        <alias field="_pipe_node_type" index="7" name=""/>
+        <alias field="_pipe_orientation" index="8" name=""/>
+        <alias field="_pipe_schema_visible" index="9" name=""/>
+        <alias field="geometry" index="10" name=""/>
+        <alias field="geometry_alt1" index="11" name=""/>
+        <alias field="geometry_alt2" index="12" name=""/>
+        <alias field="update_geometry_alt1" index="13" name=""/>
+        <alias field="update_geometry_alt2" index="14" name=""/>
+        <alias field="identification" index="15" name=""/>
+        <alias field="fk_distributor" index="16" name=""/>
+        <alias field="fk_status" index="17" name=""/>
+        <alias field="fk_folder" index="18" name=""/>
+        <alias field="fk_locationtype" index="19" name=""/>
+        <alias field="fk_precision" index="20" name=""/>
+        <alias field="fk_precisionalti" index="21" name=""/>
+        <alias field="fk_object_reference" index="22" name=""/>
+        <alias field="altitude" index="23" name=""/>
+        <alias field="year" index="24" name=""/>
+        <alias field="year_end" index="25" name=""/>
+        <alias field="orientation" index="26" name=""/>
+        <alias field="remark" index="27" name=""/>
+        <alias field="schema_force_visible" index="28" name=""/>
+        <alias field="label_1_visible" index="29" name=""/>
+        <alias field="label_1_x" index="30" name=""/>
+        <alias field="label_1_y" index="31" name=""/>
+        <alias field="label_1_rotation" index="32" name=""/>
+        <alias field="label_1_text" index="33" name=""/>
+        <alias field="label_2_visible" index="34" name=""/>
+        <alias field="label_2_x" index="35" name=""/>
+        <alias field="label_2_y" index="36" name=""/>
+        <alias field="label_2_rotation" index="37" name=""/>
+        <alias field="label_2_text" index="38" name=""/>
+        <alias field="installation_type" index="39" name=""/>
+        <alias field="name" index="40" name=""/>
+        <alias field="fk_parent" index="41" name=""/>
+        <alias field="fk_remote" index="42" name=""/>
+        <alias field="fk_watertype" index="43" name=""/>
+        <alias field="parcel" index="44" name=""/>
+        <alias field="eca" index="45" name=""/>
+        <alias field="open_water_surface" index="46" name=""/>
+        <alias field="fk_source_type" index="47" name=""/>
+        <alias field="fk_source_quality" index="48" name=""/>
+        <alias field="flow_lowest" index="49" name=""/>
+        <alias field="flow_average" index="50" name=""/>
+        <alias field="flow_concession" index="51" name=""/>
+        <alias field="contract_end" index="52" name=""/>
+        <alias field="gathering_chamber" index="53" name=""/>
+        <alias field="fk_pump_type" index="54" name=""/>
+        <alias field="fk_pipe_in" index="55" name=""/>
+        <alias field="fk_pipe_out" index="56" name=""/>
+        <alias field="fk_pump_operating" index="57" name=""/>
+        <alias field="no_pumps" index="58" name=""/>
+        <alias field="rejected_flow" index="59" name=""/>
+        <alias field="manometric_height" index="60" name=""/>
+        <alias field="fk_overflow" index="61" name=""/>
+        <alias field="fk_tank_firestorage" index="62" name=""/>
+        <alias field="storage_total" index="63" name=""/>
+        <alias field="storage_supply" index="64" name=""/>
+        <alias field="storage_fire" index="65" name=""/>
+        <alias field="altitude_overflow" index="66" name=""/>
+        <alias field="altitude_apron" index="67" name=""/>
+        <alias field="height_max" index="68" name=""/>
+        <alias field="fire_valve" index="69" name=""/>
+        <alias field="fire_remote" index="70" name=""/>
+        <alias field="_litrepercm" index="71" name=""/>
+        <alias field="cistern1_fk_type" index="72" name=""/>
+        <alias field="cistern1_dimension_1" index="73" name=""/>
+        <alias field="cistern1_dimension_2" index="74" name=""/>
+        <alias field="cistern1_storage" index="75" name=""/>
+        <alias field="_cistern1_litrepercm" index="76" name=""/>
+        <alias field="cistern2_fk_type" index="77" name=""/>
+        <alias field="cistern2_dimension_1" index="78" name=""/>
+        <alias field="cistern2_dimension_2" index="79" name=""/>
+        <alias field="cistern2_storage" index="80" name=""/>
+        <alias field="_cistern2_litrepercm" index="81" name=""/>
+        <alias field="sanitization_uv" index="82" name=""/>
+        <alias field="sanitization_chlorine_liquid" index="83" name=""/>
+        <alias field="sanitization_chlorine_gazeous" index="84" name=""/>
+        <alias field="sanitization_ozone" index="85" name=""/>
+        <alias field="filtration_membrane" index="86" name=""/>
+        <alias field="filtration_sandorgravel" index="87" name=""/>
+        <alias field="flocculation" index="88" name=""/>
+        <alias field="activatedcharcoal" index="89" name=""/>
+        <alias field="settling" index="90" name=""/>
+        <alias field="treatment_capacity" index="91" name=""/>
+        <alias field="networkseparation" index="92" name=""/>
+        <alias field="flow_meter" index="93" name=""/>
+        <alias field="water_meter" index="94" name=""/>
+        <alias field="manometer" index="95" name=""/>
+        <alias field="depth" index="96" name=""/>
+        <alias field="no_valves" index="97" name=""/>
+        <alias field="fk_pressurecontrol_type" index="98" name=""/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <attributeactions default="-1"/>
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+        <columns>
+          <column width="-1" hidden="0" type="field" name="id"/>
+          <column width="-1" hidden="0" type="field" name="fk_district"/>
+          <column width="-1" hidden="0" type="field" name="fk_pressurezone"/>
+          <column width="-1" hidden="0" type="field" name="fk_printmap"/>
+          <column width="-1" hidden="0" type="field" name="_printmaps"/>
+          <column width="-1" hidden="0" type="field" name="_geometry_alt1_used"/>
+          <column width="-1" hidden="0" type="field" name="_geometry_alt2_used"/>
+          <column width="-1" hidden="0" type="field" name="_pipe_node_type"/>
+          <column width="-1" hidden="0" type="field" name="_pipe_orientation"/>
+          <column width="-1" hidden="0" type="field" name="_pipe_schema_visible"/>
+          <column width="-1" hidden="0" type="field" name="geometry_alt1"/>
+          <column width="-1" hidden="0" type="field" name="geometry_alt2"/>
+          <column width="-1" hidden="0" type="field" name="update_geometry_alt1"/>
+          <column width="-1" hidden="0" type="field" name="update_geometry_alt2"/>
+          <column width="-1" hidden="0" type="field" name="identification"/>
+          <column width="-1" hidden="0" type="field" name="fk_distributor"/>
+          <column width="-1" hidden="0" type="field" name="fk_status"/>
+          <column width="-1" hidden="0" type="field" name="fk_folder"/>
+          <column width="-1" hidden="0" type="field" name="fk_locationtype"/>
+          <column width="-1" hidden="0" type="field" name="year"/>
+          <column width="-1" hidden="0" type="field" name="year_end"/>
+          <column width="-1" hidden="0" type="field" name="remark"/>
+          <column width="-1" hidden="0" type="field" name="schema_force_visible"/>
+          <column width="-1" hidden="0" type="field" name="label_1_visible"/>
+          <column width="-1" hidden="0" type="field" name="label_1_x"/>
+          <column width="-1" hidden="0" type="field" name="label_1_y"/>
+          <column width="-1" hidden="0" type="field" name="label_1_rotation"/>
+          <column width="-1" hidden="0" type="field" name="label_1_text"/>
+          <column width="-1" hidden="0" type="field" name="label_2_visible"/>
+          <column width="-1" hidden="0" type="field" name="label_2_x"/>
+          <column width="-1" hidden="0" type="field" name="label_2_y"/>
+          <column width="-1" hidden="0" type="field" name="label_2_rotation"/>
+          <column width="-1" hidden="0" type="field" name="label_2_text"/>
+          <column width="-1" hidden="0" type="field" name="fk_precision"/>
+          <column width="-1" hidden="0" type="field" name="fk_precisionalti"/>
+          <column width="-1" hidden="0" type="field" name="fk_object_reference"/>
+          <column width="-1" hidden="0" type="field" name="altitude"/>
+          <column width="-1" hidden="0" type="field" name="orientation"/>
+          <column width="-1" hidden="0" type="field" name="installation_type"/>
+          <column width="-1" hidden="0" type="field" name="name"/>
+          <column width="-1" hidden="0" type="field" name="fk_parent"/>
+          <column width="-1" hidden="0" type="field" name="fk_remote"/>
+          <column width="-1" hidden="0" type="field" name="fk_watertype"/>
+          <column width="-1" hidden="0" type="field" name="parcel"/>
+          <column width="-1" hidden="0" type="field" name="eca"/>
+          <column width="-1" hidden="0" type="field" name="open_water_surface"/>
+          <column width="-1" hidden="0" type="field" name="fk_source_type"/>
+          <column width="-1" hidden="0" type="field" name="fk_source_quality"/>
+          <column width="-1" hidden="0" type="field" name="flow_lowest"/>
+          <column width="-1" hidden="0" type="field" name="flow_average"/>
+          <column width="-1" hidden="0" type="field" name="flow_concession"/>
+          <column width="-1" hidden="0" type="field" name="contract_end"/>
+          <column width="-1" hidden="0" type="field" name="gathering_chamber"/>
+          <column width="-1" hidden="0" type="field" name="fk_pump_type"/>
+          <column width="-1" hidden="0" type="field" name="fk_pipe_in"/>
+          <column width="-1" hidden="0" type="field" name="fk_pipe_out"/>
+          <column width="-1" hidden="0" type="field" name="fk_pump_operating"/>
+          <column width="-1" hidden="0" type="field" name="no_pumps"/>
+          <column width="-1" hidden="0" type="field" name="rejected_flow"/>
+          <column width="-1" hidden="0" type="field" name="manometric_height"/>
+          <column width="-1" hidden="0" type="field" name="fk_overflow"/>
+          <column width="-1" hidden="0" type="field" name="fk_tank_firestorage"/>
+          <column width="-1" hidden="0" type="field" name="storage_total"/>
+          <column width="-1" hidden="0" type="field" name="storage_supply"/>
+          <column width="-1" hidden="0" type="field" name="storage_fire"/>
+          <column width="-1" hidden="0" type="field" name="altitude_overflow"/>
+          <column width="-1" hidden="0" type="field" name="altitude_apron"/>
+          <column width="-1" hidden="0" type="field" name="height_max"/>
+          <column width="-1" hidden="0" type="field" name="fire_valve"/>
+          <column width="-1" hidden="0" type="field" name="fire_remote"/>
+          <column width="-1" hidden="0" type="field" name="_litrepercm"/>
+          <column width="-1" hidden="0" type="field" name="cistern1_fk_type"/>
+          <column width="-1" hidden="0" type="field" name="cistern1_dimension_1"/>
+          <column width="-1" hidden="0" type="field" name="cistern1_dimension_2"/>
+          <column width="-1" hidden="0" type="field" name="cistern1_storage"/>
+          <column width="-1" hidden="0" type="field" name="_cistern1_litrepercm"/>
+          <column width="-1" hidden="0" type="field" name="cistern2_fk_type"/>
+          <column width="-1" hidden="0" type="field" name="cistern2_dimension_1"/>
+          <column width="-1" hidden="0" type="field" name="cistern2_dimension_2"/>
+          <column width="-1" hidden="0" type="field" name="cistern2_storage"/>
+          <column width="-1" hidden="0" type="field" name="_cistern2_litrepercm"/>
+          <column width="-1" hidden="0" type="field" name="sanitization_uv"/>
+          <column width="-1" hidden="0" type="field" name="sanitization_chlorine_liquid"/>
+          <column width="-1" hidden="0" type="field" name="sanitization_chlorine_gazeous"/>
+          <column width="-1" hidden="0" type="field" name="sanitization_ozone"/>
+          <column width="-1" hidden="0" type="field" name="filtration_membrane"/>
+          <column width="-1" hidden="0" type="field" name="filtration_sandorgravel"/>
+          <column width="-1" hidden="0" type="field" name="flocculation"/>
+          <column width="-1" hidden="0" type="field" name="activatedcharcoal"/>
+          <column width="-1" hidden="0" type="field" name="settling"/>
+          <column width="-1" hidden="0" type="field" name="treatment_capacity"/>
+          <column width="-1" hidden="0" type="field" name="networkseparation"/>
+          <column width="-1" hidden="0" type="field" name="flow_meter"/>
+          <column width="-1" hidden="0" type="field" name="water_meter"/>
+          <column width="-1" hidden="0" type="field" name="manometer"/>
+          <column width="-1" hidden="0" type="field" name="depth"/>
+          <column width="-1" hidden="0" type="field" name="no_valves"/>
+          <column width="-1" hidden="0" type="field" name="fk_pressurecontrol_type"/>
+          <column width="-1" hidden="1" type="actions"/>
+          <column width="-1" hidden="0" type="field" name="geometry"/>
+        </columns>
+      </attributetableconfig>
+      <editform>./ui_forms/installation.ui</editform>
+      <editforminit>formOpen</editforminit>
+      <editforminitcodesource>1</editforminitcodesource>
+      <editforminitfilepath>./python/installation_form.py</editforminitfilepath>
+      <editforminitcode><![CDATA[from python.installation_form import formOpen
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>uifilelayout</editorlayout>
+      <widgets>
+        <widget name="relation_cover_installation">
+          <config/>
+        </widget>
+        <widget name="relation_installation_parent">
+          <config/>
+        </widget>
+      </widgets>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="geometry" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="fk_locationtype" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_precisionalti" expression=""/>
+        <default field="fk_object_reference" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="orientation" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="installation_type" expression=""/>
+        <default field="name" expression=""/>
+        <default field="fk_parent" expression=""/>
+        <default field="fk_remote" expression=""/>
+        <default field="fk_watertype" expression=""/>
+        <default field="parcel" expression=""/>
+        <default field="eca" expression=""/>
+        <default field="open_water_surface" expression=""/>
+        <default field="fk_source_type" expression=""/>
+        <default field="fk_source_quality" expression=""/>
+        <default field="flow_lowest" expression=""/>
+        <default field="flow_average" expression=""/>
+        <default field="flow_concession" expression=""/>
+        <default field="contract_end" expression=""/>
+        <default field="gathering_chamber" expression=""/>
+        <default field="fk_pump_type" expression=""/>
+        <default field="fk_pipe_in" expression=""/>
+        <default field="fk_pipe_out" expression=""/>
+        <default field="fk_pump_operating" expression=""/>
+        <default field="no_pumps" expression=""/>
+        <default field="rejected_flow" expression=""/>
+        <default field="manometric_height" expression=""/>
+        <default field="fk_overflow" expression=""/>
+        <default field="fk_tank_firestorage" expression=""/>
+        <default field="storage_total" expression=""/>
+        <default field="storage_supply" expression=""/>
+        <default field="storage_fire" expression=""/>
+        <default field="altitude_overflow" expression=""/>
+        <default field="altitude_apron" expression=""/>
+        <default field="height_max" expression=""/>
+        <default field="fire_valve" expression=""/>
+        <default field="fire_remote" expression=""/>
+        <default field="_litrepercm" expression=""/>
+        <default field="cistern1_fk_type" expression=""/>
+        <default field="cistern1_dimension_1" expression=""/>
+        <default field="cistern1_dimension_2" expression=""/>
+        <default field="cistern1_storage" expression=""/>
+        <default field="_cistern1_litrepercm" expression=""/>
+        <default field="cistern2_fk_type" expression=""/>
+        <default field="cistern2_dimension_1" expression=""/>
+        <default field="cistern2_dimension_2" expression=""/>
+        <default field="cistern2_storage" expression=""/>
+        <default field="_cistern2_litrepercm" expression=""/>
+        <default field="sanitization_uv" expression=""/>
+        <default field="sanitization_chlorine_liquid" expression=""/>
+        <default field="sanitization_chlorine_gazeous" expression=""/>
+        <default field="sanitization_ozone" expression=""/>
+        <default field="filtration_membrane" expression=""/>
+        <default field="filtration_sandorgravel" expression=""/>
+        <default field="flocculation" expression=""/>
+        <default field="activatedcharcoal" expression=""/>
+        <default field="settling" expression=""/>
+        <default field="treatment_capacity" expression=""/>
+        <default field="networkseparation" expression=""/>
+        <default field="flow_meter" expression=""/>
+        <default field="water_meter" expression=""/>
+        <default field="manometer" expression=""/>
+        <default field="depth" expression=""/>
+        <default field="no_valves" expression=""/>
+        <default field="fk_pressurecontrol_type" expression=""/>
+      </defaults>
+      <previewExpression>coalesce(identification|| ' ','') || CASE
+WHEN  "installation_type"  = 'chamber' THEN 'C. '
+WHEN "installation_type"  = 'pressurecontrol' AND fk_pressurecontrol_type = 2801 THEN 'CR. '
+WHEN  "installation_type"  = 'pressurecontrol' AND fk_pressurecontrol_type = 2802 THEN 'CCP. '
+WHEN  "installation_type"  = 'pressurecontrol' AND fk_pressurecontrol_type = 2803 THEN 'CRA. '
+WHEN  "installation_type"  = 'pump' THEN 'P. '
+WHEN  "installation_type"  = 'source' THEN 'S. '
+WHEN  "installation_type"  = 'tank' THEN 'R. '
+WHEN  "installation_type"  = 'treatment' THEN 'T. '
+ELSE ''
+END
+|| coalesce(name,'')</previewExpression>
     </maplayer>
     <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>

--- a/qgis-project/qwat.qgs
+++ b/qgis-project/qwat.qgs
@@ -5,7 +5,7 @@
   <evaluateDefaultValues active="0"/>
   <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="">
     <customproperties/>
-    <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="QWAT">
+    <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="Réseau">
       <customproperties/>
       <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="ouvrages">
         <customproperties/>
@@ -52,65 +52,62 @@
           <customproperties/>
         </layer-tree-layer>
       </layer-tree-group>
-      <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="Réseau">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="conduites_copy20130709141244955" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineStringZ table=&quot;qwat_od&quot;.&quot;pipe&quot; (geometry) sql=" name="conduites">
+        <customproperties>
+          <property key="expandedLegendNodes">
+            <value>{1db41c6f-d632-42a2-a453-287300377f48}</value>
+            <value>{cbedc12d-c79c-4e2f-b007-5bbfcaa3cfd2}</value>
+            <value>{85a03431-ffdc-4bd4-9796-2113d60c4125}</value>
+            <value>{d7cd7ce7-c1fb-444f-9fd7-375e42e1119d}</value>
+            <value>{5b970fd5-5c37-4865-81a5-cab18c5fb58c}</value>
+            <value>{7d0cfa7a-eaf4-499a-b977-1238b90ca15f}</value>
+            <value>{2e14d53a-6d2f-40b3-bf3b-4f32112e3d59}</value>
+          </property>
+          <property key="showFeatureCount" value="0"/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="node20130304110005126" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;node&quot; (geometry) sql=" name="noeuds">
+        <customproperties>
+          <property key="showFeatureCount" value="0"/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="valve20130304110011497" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;valve&quot; (geometry) sql=" name="vannes">
+        <customproperties>
+          <property key="expandedLegendNodes">
+            <value>{7a025dab-c7fe-4c7c-9f0b-25a39f73abd8}</value>
+            <value>{143022c7-b3e1-4c03-80d5-58520da677c2}</value>
+          </property>
+          <property key="showFeatureCount" value="1"/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="hydrant20130304110004848" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_hydrant&quot; (geometry) sql=" name="hydrantes">
         <customproperties/>
-        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="conduites_copy20130709141244955" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineStringZ table=&quot;qwat_od&quot;.&quot;pipe&quot; (geometry) sql=" name="conduites">
-          <customproperties>
-            <property key="expandedLegendNodes">
-              <value>{1db41c6f-d632-42a2-a453-287300377f48}</value>
-              <value>{cbedc12d-c79c-4e2f-b007-5bbfcaa3cfd2}</value>
-              <value>{85a03431-ffdc-4bd4-9796-2113d60c4125}</value>
-              <value>{d7cd7ce7-c1fb-444f-9fd7-375e42e1119d}</value>
-              <value>{5b970fd5-5c37-4865-81a5-cab18c5fb58c}</value>
-              <value>{7d0cfa7a-eaf4-499a-b977-1238b90ca15f}</value>
-              <value>{2e14d53a-6d2f-40b3-bf3b-4f32112e3d59}</value>
-            </property>
-            <property key="showFeatureCount" value="0"/>
-          </customproperties>
-        </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="node20130304110005126" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;node&quot; (geometry) sql=" name="noeuds">
-          <customproperties>
-            <property key="showFeatureCount" value="0"/>
-          </customproperties>
-        </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="valve20130304110011497" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;valve&quot; (geometry) sql=" name="vannes">
-          <customproperties>
-            <property key="expandedLegendNodes">
-              <value>{7a025dab-c7fe-4c7c-9f0b-25a39f73abd8}</value>
-              <value>{143022c7-b3e1-4c03-80d5-58520da677c2}</value>
-            </property>
-            <property key="showFeatureCount" value="1"/>
-          </customproperties>
-        </layer-tree-layer>
-        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="hydrant20130304110004848" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_hydrant&quot; (geometry) sql=" name="hydrantes">
-          <customproperties/>
-        </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="od_part20140429113327995" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_part&quot; (geometry) sql=" name="Pièces d'installations">
-          <customproperties>
-            <property key="showFeatureCount" value="1"/>
-          </customproperties>
-        </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="od_remote20150116100522170" source="service='qwat' sslmode=disable key='id' srid=21781 type=MultiLineString table=&quot;qwat_od&quot;.&quot;remote&quot; (geometry) sql=" name="télécommandes">
-          <customproperties>
-            <property key="showFeatureCount" value="1"/>
-          </customproperties>
-        </layer-tree-layer>
-        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="od_crossing20141023083754327" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;crossing&quot; (geometry) sql=" name="croisements">
-          <customproperties>
-            <property key="showFeatureCount" value="1"/>
-          </customproperties>
-        </layer-tree-layer>
-        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="leak20130821111917060" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;leak&quot; (geometry) sql=" name="fuites">
-          <customproperties>
-            <property key="showFeatureCount" value="1"/>
-          </customproperties>
-        </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vw_element_samplingpoint20151002161215716" source="service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_samplingpoint&quot; (geometry) sql=" name="point de prélèvement">
-          <customproperties>
-            <property key="showFeatureCount" value="1"/>
-          </customproperties>
-        </layer-tree-layer>
-      </layer-tree-group>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="od_part20140429113327995" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_part&quot; (geometry) sql=" name="Pièces d'installations">
+        <customproperties>
+          <property key="showFeatureCount" value="1"/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="od_remote20150116100522170" source="service='qwat' sslmode=disable key='id' srid=21781 type=MultiLineString table=&quot;qwat_od&quot;.&quot;remote&quot; (geometry) sql=" name="télécommandes">
+        <customproperties>
+          <property key="showFeatureCount" value="1"/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="od_crossing20141023083754327" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;crossing&quot; (geometry) sql=" name="croisements">
+        <customproperties>
+          <property key="showFeatureCount" value="1"/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="leak20130821111917060" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;leak&quot; (geometry) sql=" name="fuites">
+        <customproperties>
+          <property key="showFeatureCount" value="1"/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vw_element_samplingpoint20151002161215716" source="service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_samplingpoint&quot; (geometry) sql=" name="point de prélèvement">
+        <customproperties>
+          <property key="showFeatureCount" value="1"/>
+        </customproperties>
+      </layer-tree-layer>
       <layer-tree-group expanded="1" checked="Qt::Unchecked" name="Contrôle">
         <customproperties/>
         <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="subscriber_pipe_relation20130417092124312" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineString table=&quot;qwat_od&quot;.&quot;vw_subscriber_pipe_relation&quot; (geometry) sql=" name="Fleches abonné -> conduite">
@@ -605,7 +602,7 @@
     </custom-order>
   </layer-tree-canvas>
   <legend updateDrawingOrder="false">
-    <legendgroup open="true" checked="Qt::PartiallyChecked" name="QWAT">
+    <legendgroup open="true" checked="Qt::PartiallyChecked" name="Réseau">
       <legendgroup open="true" checked="Qt::PartiallyChecked" name="ouvrages">
         <legendlayer drawingOrder="1" open="false" checked="Qt::Checked" name="ouvrage" showFeatureCount="1">
           <filegroup open="false" hidden="false">
@@ -640,53 +637,51 @@
           </filegroup>
         </legendlayer>
       </legendgroup>
-      <legendgroup open="true" checked="Qt::PartiallyChecked" name="Réseau">
-        <legendlayer drawingOrder="14" open="true" checked="Qt::Checked" name="conduites" showFeatureCount="0">
-          <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="conduites_copy20130709141244955" visible="1"/>
-          </filegroup>
-        </legendlayer>
-        <legendlayer drawingOrder="11" open="true" checked="Qt::Checked" name="noeuds" showFeatureCount="0">
-          <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="node20130304110005126" visible="1"/>
-          </filegroup>
-        </legendlayer>
-        <legendlayer drawingOrder="7" open="true" checked="Qt::Checked" name="vannes" showFeatureCount="1">
-          <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="valve20130304110011497" visible="1"/>
-          </filegroup>
-        </legendlayer>
-        <legendlayer drawingOrder="8" open="false" checked="Qt::Checked" name="hydrantes" showFeatureCount="0">
-          <filegroup open="false" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="hydrant20130304110004848" visible="1"/>
-          </filegroup>
-        </legendlayer>
-        <legendlayer drawingOrder="10" open="true" checked="Qt::Checked" name="Pièces d'installations" showFeatureCount="1">
-          <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="od_part20140429113327995" visible="1"/>
-          </filegroup>
-        </legendlayer>
-        <legendlayer drawingOrder="19" open="true" checked="Qt::Checked" name="télécommandes" showFeatureCount="1">
-          <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="od_remote20150116100522170" visible="1"/>
-          </filegroup>
-        </legendlayer>
-        <legendlayer drawingOrder="13" open="false" checked="Qt::Checked" name="croisements" showFeatureCount="1">
-          <filegroup open="false" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="od_crossing20141023083754327" visible="1"/>
-          </filegroup>
-        </legendlayer>
-        <legendlayer drawingOrder="9" open="false" checked="Qt::Unchecked" name="fuites" showFeatureCount="1">
-          <filegroup open="false" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="leak20130821111917060" visible="0"/>
-          </filegroup>
-        </legendlayer>
-        <legendlayer drawingOrder="68" open="true" checked="Qt::Unchecked" name="point de prélèvement" showFeatureCount="1">
-          <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="vw_element_samplingpoint20151002161215716" visible="0"/>
-          </filegroup>
-        </legendlayer>
-      </legendgroup>
+      <legendlayer drawingOrder="14" open="true" checked="Qt::Checked" name="conduites" showFeatureCount="0">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile isInOverview="0" layerid="conduites_copy20130709141244955" visible="1"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer drawingOrder="11" open="true" checked="Qt::Checked" name="noeuds" showFeatureCount="0">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile isInOverview="0" layerid="node20130304110005126" visible="1"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer drawingOrder="7" open="true" checked="Qt::Checked" name="vannes" showFeatureCount="1">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile isInOverview="0" layerid="valve20130304110011497" visible="1"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer drawingOrder="8" open="false" checked="Qt::Checked" name="hydrantes" showFeatureCount="0">
+        <filegroup open="false" hidden="false">
+          <legendlayerfile isInOverview="0" layerid="hydrant20130304110004848" visible="1"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer drawingOrder="10" open="false" checked="Qt::Checked" name="Pièces d'installations" showFeatureCount="1">
+        <filegroup open="false" hidden="false">
+          <legendlayerfile isInOverview="0" layerid="od_part20140429113327995" visible="1"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer drawingOrder="19" open="true" checked="Qt::Checked" name="télécommandes" showFeatureCount="1">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile isInOverview="0" layerid="od_remote20150116100522170" visible="1"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer drawingOrder="13" open="false" checked="Qt::Checked" name="croisements" showFeatureCount="1">
+        <filegroup open="false" hidden="false">
+          <legendlayerfile isInOverview="0" layerid="od_crossing20141023083754327" visible="1"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer drawingOrder="9" open="false" checked="Qt::Unchecked" name="fuites" showFeatureCount="1">
+        <filegroup open="false" hidden="false">
+          <legendlayerfile isInOverview="0" layerid="leak20130821111917060" visible="0"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer drawingOrder="68" open="true" checked="Qt::Unchecked" name="point de prélèvement" showFeatureCount="1">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile isInOverview="0" layerid="vw_element_samplingpoint20151002161215716" visible="0"/>
+        </filegroup>
+      </legendlayer>
       <legendgroup open="true" checked="Qt::Unchecked" name="Contrôle">
         <legendlayer drawingOrder="6" open="false" checked="Qt::Unchecked" name="Fleches abonné -> conduite" showFeatureCount="0">
           <filegroup open="false" hidden="false">

--- a/qgis-project/qwat.qgs
+++ b/qgis-project/qwat.qgs
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis projectname="" version="2.18.3">
+<qgis projectname="" version="2.18.10">
   <title></title>
   <autotransaction active="0"/>
   <evaluateDefaultValues active="0"/>
@@ -9,7 +9,7 @@
       <customproperties/>
       <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="ouvrages">
         <customproperties/>
-        <layer-tree-layer expanded="0" checked="Qt::Checked" id="vw_node_installation20150918153835436" name="ouvrage">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="vw_node_installation20150918153835436" source="service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_installation&quot; (geometry) sql=" name="ouvrage">
           <customproperties>
             <property key="expandedLegendNodes">
               <value>{69b3bf49-4ced-4bb9-8799-da2f168ad22c}</value>
@@ -29,7 +29,7 @@
             <property key="showFeatureCount" value="1"/>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="od_cover20141219115626229" name="couvercles">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="od_cover20141219115626229" source="service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;cover&quot; (geometry) sql=" name="couvercles">
           <customproperties>
             <property key="showFeatureCount" value="1"/>
           </customproperties>
@@ -37,24 +37,24 @@
       </layer-tree-group>
       <layer-tree-group expanded="1" checked="Qt::Checked" name="Abonnés">
         <customproperties/>
-        <layer-tree-layer expanded="1" checked="Qt::Checked" id="subscriber20130304110011459" name="abonnés">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="subscriber20130304110011459" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_subscriber&quot; (geometry) sql=" name="abonnés">
           <customproperties>
             <property key="showFeatureCount" value="0"/>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" checked="Qt::Checked" id="od_subscriber_reference20131206105928067" name="abonnés - renvoi">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="od_subscriber_reference20131206105928067" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;subscriber_reference&quot; (geometry) sql=" name="abonnés - renvoi">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" checked="Qt::Checked" id="od_meter20131120073630165" name="compteur réseau">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="od_meter20131120073630165" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_meter&quot; (geometry) sql=" name="compteurs réseau">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" checked="Qt::Checked" id="od_meter_reference20140304165835390" name="Compteur réseau - renvoi">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="od_meter_reference20140304165835390" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;meter_reference&quot; (geometry) sql=" name="Compteurs réseau - renvoi">
           <customproperties/>
         </layer-tree-layer>
       </layer-tree-group>
       <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="Réseau">
         <customproperties/>
-        <layer-tree-layer expanded="1" checked="Qt::Checked" id="conduites_copy20130709141244955" name="conduites">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="conduites_copy20130709141244955" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineStringZ table=&quot;qwat_od&quot;.&quot;pipe&quot; (geometry) sql=" name="conduites">
           <customproperties>
             <property key="expandedLegendNodes">
               <value>{1db41c6f-d632-42a2-a453-287300377f48}</value>
@@ -68,12 +68,12 @@
             <property key="showFeatureCount" value="0"/>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" checked="Qt::Checked" id="node20130304110005126" name="noeuds">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="node20130304110005126" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;node&quot; (geometry) sql=" name="noeuds">
           <customproperties>
             <property key="showFeatureCount" value="0"/>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" checked="Qt::Checked" id="valve20130304110011497" name="vannes">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="valve20130304110011497" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;valve&quot; (geometry) sql=" name="vannes">
           <customproperties>
             <property key="expandedLegendNodes">
               <value>{7a025dab-c7fe-4c7c-9f0b-25a39f73abd8}</value>
@@ -82,30 +82,30 @@
             <property key="showFeatureCount" value="1"/>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" checked="Qt::Checked" id="hydrant20130304110004848" name="hydrantes">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="hydrant20130304110004848" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_hydrant&quot; (geometry) sql=" name="hydrantes">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" checked="Qt::Checked" id="od_part20140429113327995" name="Pièces d'installations">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="od_part20140429113327995" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_part&quot; (geometry) sql=" name="Pièces d'installations">
           <customproperties>
             <property key="showFeatureCount" value="1"/>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" checked="Qt::Checked" id="od_remote20150116100522170" name="télécommande">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="od_remote20150116100522170" source="service='qwat' sslmode=disable key='id' srid=21781 type=MultiLineString table=&quot;qwat_od&quot;.&quot;remote&quot; (geometry) sql=" name="télécommandes">
           <customproperties>
             <property key="showFeatureCount" value="1"/>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" checked="Qt::Checked" id="od_crossing20141023083754327" name="croisements">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="od_crossing20141023083754327" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;crossing&quot; (geometry) sql=" name="croisements">
           <customproperties>
             <property key="showFeatureCount" value="1"/>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="leak20130821111917060" name="fuite">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="leak20130821111917060" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;leak&quot; (geometry) sql=" name="fuites">
           <customproperties>
             <property key="showFeatureCount" value="1"/>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vw_element_samplingpoint20151002161215716" name="point de prélèvement">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vw_element_samplingpoint20151002161215716" source="service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_samplingpoint&quot; (geometry) sql=" name="point de prélèvement">
           <customproperties>
             <property key="showFeatureCount" value="1"/>
           </customproperties>
@@ -113,10 +113,10 @@
       </layer-tree-group>
       <layer-tree-group expanded="1" checked="Qt::Unchecked" name="Contrôle">
         <customproperties/>
-        <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="subscriber_pipe_relation20130417092124312" name="Fleches abonné -> conduite">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="subscriber_pipe_relation20130417092124312" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineString table=&quot;qwat_od&quot;.&quot;vw_subscriber_pipe_relation&quot; (geometry) sql=" name="Fleches abonné -> conduite">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="od_node20140116161508743" name="noeuds - tous - controle">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="od_node20140116161508743" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;node&quot; (geometry) sql=" name="noeuds - tous - controle">
           <customproperties/>
         </layer-tree-layer>
       </layer-tree-group>
@@ -125,12 +125,12 @@
       <customproperties/>
       <layer-tree-group expanded="1" checked="Qt::Unchecked" name="impression">
         <customproperties/>
-        <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="hydrantes_copy20160127124839887" name="hydrantes 5000 (pression)">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="hydrantes_copy20160127124839887" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_hydrant&quot; (geometry) sql=" name="hydrantes 5000 (pression)">
           <customproperties>
             <property key="expandedLegendNodes" value="{a83ef0cf-9977-418a-84e8-92fa1cc4523e}"/>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="ouvrage_copy20160125132737527" name="ouvrage 5000">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="ouvrage_copy20160125132737527" source="service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_installation&quot; (geometry_alt2) sql=" name="ouvrages 5000">
           <customproperties>
             <property key="expandedLegendNodes">
               <value>{d31d075b-227e-40b6-ab03-8d810a0d69b8}</value>
@@ -138,76 +138,76 @@
             </property>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="vannes_copy20141127160745910" name="vannes 5000">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="vannes_copy20141127160745910" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;valve&quot; (geometry_alt2) sql=" name="vannes 5000">
           <customproperties>
             <property key="expandedLegendNodes"/>
           </customproperties>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vw_pipe_schema20170306143352379179081243" name="conduite impression 5000">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vw_pipe_schema20170306143352379179081243" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineStringZ table=&quot;qwat_od&quot;.&quot;vw_pipe_schema&quot; (geometry) sql=" name="conduites impression 5000">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="télécommande_copy20160127112146958" name="télécommande 5000">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="télécommande_copy20160127112146958" source="service='qwat' sslmode=disable key='id' srid=21781 type=MultiLineString table=&quot;qwat_od&quot;.&quot;remote&quot; (geometry_alt2) sql=" name="télécommande 5000">
           <customproperties/>
         </layer-tree-layer>
       </layer-tree-group>
       <layer-tree-group expanded="1" checked="Qt::Unchecked" name="edition">
         <customproperties/>
-        <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vw_pipe_schema_visibleitems20141127154708843" name="conduites edition 5000">
+        <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vw_pipe_schema_visibleitems20141127154708843" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineStringZ table=&quot;qwat_od&quot;.&quot;vw_pipe_schema_visibleitems&quot; (geometry) sql=" name="conduites edition 5000">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="pipe_child_parent20130417092030507" name="Flèche conduite enfant -> parent">
+        <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="pipe_child_parent20130417092030507" source="service='qwat' sslmode=disable key='child' srid=21781 type=LineString table=&quot;qwat_od&quot;.&quot;vw_pipe_child_parent&quot; (geometry) sql=" name="Flèches conduite enfant -> parent">
           <customproperties/>
         </layer-tree-layer>
       </layer-tree-group>
     </layer-tree-group>
     <layer-tree-group expanded="1" checked="Qt::Checked" name="Annotations">
       <customproperties/>
-      <layer-tree-layer expanded="0" checked="Qt::Checked" id="od_annotationline20131203095020365" name="annotation - ligne">
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="od_annotationline20131203095020365" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;annotationline&quot; (geometry) sql=" name="annotations - ligne">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="0" checked="Qt::Checked" id="od_annotationpoint20131203095020392" name="annotation - point">
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="od_annotationpoint20131203095020392" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_dr&quot;.&quot;annotationpoint&quot; (geometry) sql=" name="annotations - point">
         <customproperties/>
       </layer-tree-layer>
     </layer-tree-group>
     <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="Côtes">
       <customproperties/>
-      <layer-tree-layer expanded="0" checked="Qt::Checked" id="dimension20130807094904783" name="côtes distance">
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="dimension20130807094904783" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_distance&quot; (geometry) sql=" name="côtes distance">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="0" checked="Qt::Checked" id="od_dimension_orientation20131202111155806" name="côtes orientation">
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Checked" id="od_dimension_orientation20131202111155806" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_orientation&quot; (geometry) sql=" name="côtes orientation">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="constructionpoint20130807094904851" name="points de construction">
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="constructionpoint20130807094904851" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_dr&quot;.&quot;constructionpoint&quot; (geometry) sql=" name="points de construction">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="IntersectIt_Points20130618102143276" name="IntersectIt Points">
+      <layer-tree-layer expanded="0" providerKey="memory" checked="Qt::Unchecked" id="IntersectIt_Points20130618102143276" source="memory?geometry=Point&amp;crs=EPSG:21781&amp;index=yes&amp;field=id:string(255,0)" name="IntersectIt Points">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="IntersectIt_Lines20130618102142813" name="IntersectIt Lines">
+      <layer-tree-layer expanded="0" providerKey="memory" checked="Qt::Unchecked" id="IntersectIt_Lines20130618102142813" source="memory?geometry=LineString&amp;crs=EPSG:21781&amp;index=yes&amp;field=id:string(255,0)&amp;field=type:string(255,0)&amp;field=x:double(20,5)&amp;field=y:double(20,5)&amp;field=observation:double(20,5)&amp;field=precision:double(20,5)" name="IntersectIt Lines">
         <customproperties/>
       </layer-tree-layer>
     </layer-tree-group>
     <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="Zones">
       <customproperties/>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="folder20150629160924367" name="dossiers techniques">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="folder20150629160924367" source="service='qwat' sslmode=disable key='id' srid=21781 type=MultiLineString table=&quot;qwat_od&quot;.&quot;folder&quot; (geometry_line) sql=" name="dossiers techniques">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="district20130304110004764" name="communes">
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="district20130304110004764" source="service='qwat' sslmode=allow key='id' srid=21781 type=MultiPolygon table=&quot;qwat_od&quot;.&quot;district&quot; (geometry) sql=" name="communes">
         <customproperties>
           <property key="overview" value="0"/>
           <property key="showFeatureCount" value="1"/>
         </customproperties>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="pressurezone20130417133612105" name="zones de pressions">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="pressurezone20130417133612105" source="service='qwat' sslmode=disable key='id' srid=21781 type=MultiPolygon table=&quot;qwat_od&quot;.&quot;pressurezone&quot; (geometry) sql=" name="zones de pressions">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vw_consumptionzone20150508135647750" name="Zones de consommation">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vw_consumptionzone20150508135647750" source="service='qwat' sslmode=disable key='name' srid=21781 type=MultiPolygon table=&quot;qwat_od&quot;.&quot;vw_consumptionzone&quot; (geometry) sql=" name="Zones de consommation">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Checked" id="printmap20130304110011400" name="folios">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Checked" id="printmap20130304110011400" source="service='qwat' sslmode=allow key='id' srid=21781 type=Polygon table=&quot;qwat_od&quot;.&quot;printmap&quot; (geometry) sql=" name="folios">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="protectionzone20130304110011418" name="zones de protections">
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="protectionzone20130304110011418" source="service='qwat' sslmode=allow key='id' srid=21781 type=MultiPolygon table=&quot;qwat_od&quot;.&quot;protectionzone&quot; (geometry) sql=" name="zones de protections">
         <customproperties>
           <property key="showFeatureCount" value="1"/>
         </customproperties>
@@ -222,127 +222,127 @@
           <property key="embedded_project" value="../../../data/cadastre/cadastre.qgs"/>
         </customproperties>
       </layer-tree-group>
-      <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="Landeskarte_1_25_000___LK2520150306095331254" name="CN - toutes échelles">
+      <layer-tree-layer expanded="0" providerKey="wms" checked="Qt::Unchecked" id="Landeskarte_1_25_000___LK2520150306095331254" source="contextualWMSLegend=0&amp;crs=EPSG:21781&amp;dpiMode=7&amp;featureCount=10&amp;format=image/jpeg&amp;layers=ch.swisstopo.pixelkarte-farbe&amp;referer=http://map.geo.admin.ch/&amp;styles=ch.swisstopo.pixelkarte-farbe&amp;tileDimensions=Time%3D20151231&amp;tileMatrixSet=21781_26&amp;url=http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml" name="CN - toutes échelles">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="Landeskarte_1_25_000___LK2520150306095256537" name="CN - 25k">
+      <layer-tree-layer expanded="0" providerKey="wms" checked="Qt::Unchecked" id="Landeskarte_1_25_000___LK2520150306095256537" source="contextualWMSLegend=0&amp;crs=EPSG:21781&amp;dpiMode=7&amp;featureCount=10&amp;format=image/jpeg&amp;layers=ch.swisstopo.pixelkarte-farbe-pk25.noscale&amp;referer=http://map.geo.admin.ch/&amp;styles=ch.swisstopo.pixelkarte-farbe-pk25.noscale&amp;tileDimensions=Time%3D20151231&amp;tileMatrixSet=21781_27&amp;url=http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml" name="CN - 25k">
         <customproperties/>
       </layer-tree-layer>
       <layer-tree-group expanded="0" checked="Qt::Unchecked" name="CN">
         <customproperties/>
       </layer-tree-group>
-      <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="SWISSIMAGE20161031083131993" name="SWISSIMAGE">
+      <layer-tree-layer expanded="0" providerKey="wms" checked="Qt::Unchecked" id="SWISSIMAGE20161031083131993" source="contextualWMSLegend=0&amp;crs=EPSG:21781&amp;dpiMode=7&amp;featureCount=10&amp;format=image/jpeg&amp;layers=ch.swisstopo.swissimage&amp;referer=http://map.geo.admin.ch&amp;styles=ch.swisstopo.swissimage&amp;tileDimensions=Time%3Dcurrent&amp;tileMatrixSet=21781_27&amp;url=http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml" name="SWISSIMAGE">
         <customproperties/>
       </layer-tree-layer>
     </layer-tree-group>
     <layer-tree-group expanded="1" checked="Qt::Unchecked" name="Tables auxiliaires">
       <customproperties/>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="protectionzone_type20160205143014456" name="protectionzone_type">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="protectionzone_type20160205143014456" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;protectionzone_type&quot; sql=" name="protectionzone_type">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="locationtype20150922082741813" name="emplacement">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="locationtype20150922082741813" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;locationtype&quot; sql=" name="emplacement">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_subscriber_type20130304110011480" name="abonnés - type">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_subscriber_type20130304110011480" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;subscriber_type&quot; sql=" name="abonnés - type">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_pipe_protection20130304110005258" name="conduites - protection">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_pipe_protection20130304110005258" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;pipe_protection&quot; sql=" name="conduites - protection">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_pipe_material20130304110005230" name="conduites - matériaux">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_pipe_material20130304110005230" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;pipe_material&quot; sql=" name="conduites - matériaux">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_pipe_installmethod20130304110005209" name="conduites - mode de pose">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_pipe_installmethod20130304110005209" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;pipe_installmethod&quot; sql=" name="conduites - mode de pose">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_pipe_function20130304110005186" name="conduites - fonction">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_pipe_function20130304110005186" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;pipe_function&quot; sql=" name="conduites - fonction">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_cover_type20141219115626290" name="couvercles - Type">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_cover_type20141219115626290" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;cover_type&quot; sql=" name="couvercles - Type">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="distributor20130304114719702" name="distributeur">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="distributor20130304114719702" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_od&quot;.&quot;distributor&quot; sql=" name="distributeur">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_leak_cause20130822081237639" name="fuite - cause">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_leak_cause20130822081237639" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;leak_cause&quot; sql=" name="fuite - cause">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="hydrant_model_inf20160205143014472" name="hydrant_model_inf">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="hydrant_model_inf20160205143014472" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;hydrant_model_inf&quot; sql=" name="hydrant_model_inf">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="hydrant_model_sup20160205143014484" name="hydrant_model_sup">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="hydrant_model_sup20160205143014484" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;hydrant_model_sup&quot; sql=" name="hydrant_model_sup">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="hydrant_output20160205143014497" name="hydrant_output">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="hydrant_output20160205143014497" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;hydrant_output&quot; sql=" name="hydrant_output">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="hydrant_provider20130304110004893" name="hydrantes - fournisseur">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="hydrant_provider20130304110004893" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;hydrant_provider&quot; sql=" name="hydrantes - fournisseur">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="hydrant_material20150925104534891" name="hydrantes - matériau">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="hydrant_material20150925104534891" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;hydrant_material&quot; sql=" name="hydrantes - matériau">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_bedding20141219112927344" name="lit de pose">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_bedding20141219112927344" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;bedding&quot; sql=" name="lit de pose">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="pump_operating20150922083814587" name="ouvrage - pompe - mode">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="pump_operating20150922083814587" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;pump_operating&quot; sql=" name="ouvrage - pompe - mode">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_pumptype20130816140237776" name="ouvrage - pompe - type">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_pumptype20130816140237776" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;pump_type&quot; sql=" name="ouvrage - pompe - type">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="pressurecontrol_type20150203100321270" name="Ouvrage - rég. de pression - type">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="pressurecontrol_type20150203100321270" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;pressurecontrol_type&quot; sql=" name="Ouvrage - rég. de pression - type">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_overflow20130304170704046" name="Ouvrage - réservoir - type trop plein">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_overflow20130304170704046" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;overflow&quot; sql=" name="Ouvrage - réservoir - type trop plein">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_tank_firestorage20130304170704030" name="Ouvrage - réservoir - type incendie">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_tank_firestorage20130304170704030" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;tank_firestorage&quot; sql=" name="Ouvrage - réservoir - type incendie">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_cistern20130304110005061" name="Ouvrage - réservoir - type de cuve">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_cistern20130304110005061" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;cistern&quot; sql=" name="Ouvrage - réservoir - type de cuve">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_sourcequality20130820110518810" name="ouvrage - source - qualité">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_sourcequality20130820110518810" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;source_quality&quot; sql=" name="ouvrage - source - qualité">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_sourcetype20130820110518791" name="ouvrage - source - type">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_sourcetype20130820110518791" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;source_type&quot; sql=" name="ouvrage - source - type">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="vl_part_type20140429114640509" name="pièces d'installation - type">
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="vl_part_type20140429114640509" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true table=&quot;qwat_vl&quot;.&quot;part_type&quot; sql=" name="pièces d'installation - type">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="object_reference20150922083109152" name="point de référence">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="object_reference20150922083109152" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;object_reference&quot; sql=" name="point de référence">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_precision20130304110011372" name="précision">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_precision20130304110011372" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;precision&quot; sql=" name="précision">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="vl_precisionalti20131211161429510" name="précision altimétrique">
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="vl_precisionalti20131211161429510" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true table=&quot;qwat_vl&quot;.&quot;precisionalti&quot; sql=" name="précision altimétrique">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="remote_type20130304110004987" name="Télécommande - type">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="remote_type20130304110004987" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;remote_type&quot; sql=" name="Télécommande - type">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_status20130304110011436" name="Statut">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_status20130304110011436" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;status&quot; sql=" name="Statut">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="0" checked="Qt::Unchecked" id="vl_watertype20131217141603877" name="Type d'eau">
+      <layer-tree-layer expanded="0" providerKey="postgres" checked="Qt::Unchecked" id="vl_watertype20131217141603877" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true table=&quot;qwat_vl&quot;.&quot;watertype&quot; sql=" name="Type d'eau">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="valve_actuation20150608112911022" name="vanne - actionnement">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="valve_actuation20150608112911022" source="service='qwat' sslmode=disable key='id' table=&quot;qwat_vl&quot;.&quot;valve_actuation&quot; sql=" name="vanne - actionnement">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_valve_maintenance20130304110011567" name="Vannes - maintenance">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_valve_maintenance20130304110011567" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;valve_maintenance&quot; sql=" name="Vannes - maintenance">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_valve_type20130304110011685" name="Vannes - type">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_valve_type20130304110011685" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;valve_type&quot; sql=" name="Vannes - type">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_valve_function20130304110011544" name="Vannes - fonction">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_valve_function20130304110011544" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;valve_function&quot; sql=" name="Vannes - fonction">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer expanded="1" checked="Qt::Unchecked" id="vl_visible20130304110011703" name="Visibilité">
+      <layer-tree-layer expanded="1" providerKey="postgres" checked="Qt::Unchecked" id="vl_visible20130304110011703" source="service='qwat' sslmode=allow key='id' table=&quot;qwat_vl&quot;.&quot;visible&quot; sql=" name="Visibilité">
         <customproperties/>
       </layer-tree-layer>
     </layer-tree-group>
@@ -629,12 +629,12 @@
             <legendlayerfile isInOverview="0" layerid="od_subscriber_reference20131206105928067" visible="1"/>
           </filegroup>
         </legendlayer>
-        <legendlayer drawingOrder="4" open="false" checked="Qt::Checked" name="compteur réseau" showFeatureCount="0">
+        <legendlayer drawingOrder="4" open="false" checked="Qt::Checked" name="compteurs réseau" showFeatureCount="0">
           <filegroup open="false" hidden="false">
             <legendlayerfile isInOverview="0" layerid="od_meter20131120073630165" visible="1"/>
           </filegroup>
         </legendlayer>
-        <legendlayer drawingOrder="5" open="false" checked="Qt::Checked" name="Compteur réseau - renvoi" showFeatureCount="0">
+        <legendlayer drawingOrder="5" open="false" checked="Qt::Checked" name="Compteurs réseau - renvoi" showFeatureCount="0">
           <filegroup open="false" hidden="false">
             <legendlayerfile isInOverview="0" layerid="od_meter_reference20140304165835390" visible="1"/>
           </filegroup>
@@ -666,7 +666,7 @@
             <legendlayerfile isInOverview="0" layerid="od_part20140429113327995" visible="1"/>
           </filegroup>
         </legendlayer>
-        <legendlayer drawingOrder="19" open="true" checked="Qt::Checked" name="télécommande" showFeatureCount="1">
+        <legendlayer drawingOrder="19" open="true" checked="Qt::Checked" name="télécommandes" showFeatureCount="1">
           <filegroup open="true" hidden="false">
             <legendlayerfile isInOverview="0" layerid="od_remote20150116100522170" visible="1"/>
           </filegroup>
@@ -676,7 +676,7 @@
             <legendlayerfile isInOverview="0" layerid="od_crossing20141023083754327" visible="1"/>
           </filegroup>
         </legendlayer>
-        <legendlayer drawingOrder="9" open="false" checked="Qt::Unchecked" name="fuite" showFeatureCount="1">
+        <legendlayer drawingOrder="9" open="false" checked="Qt::Unchecked" name="fuites" showFeatureCount="1">
           <filegroup open="false" hidden="false">
             <legendlayerfile isInOverview="0" layerid="leak20130821111917060" visible="0"/>
           </filegroup>
@@ -707,7 +707,7 @@
             <legendlayerfile isInOverview="0" layerid="hydrantes_copy20160127124839887" visible="0"/>
           </filegroup>
         </legendlayer>
-        <legendlayer drawingOrder="15" open="false" checked="Qt::Unchecked" name="ouvrage 5000" showFeatureCount="0">
+        <legendlayer drawingOrder="15" open="false" checked="Qt::Unchecked" name="ouvrages 5000" showFeatureCount="0">
           <filegroup open="false" hidden="false">
             <legendlayerfile isInOverview="0" layerid="ouvrage_copy20160125132737527" visible="0"/>
           </filegroup>
@@ -717,7 +717,7 @@
             <legendlayerfile isInOverview="0" layerid="vannes_copy20141127160745910" visible="0"/>
           </filegroup>
         </legendlayer>
-        <legendlayer drawingOrder="75" open="true" checked="Qt::Unchecked" name="conduite impression 5000" showFeatureCount="0">
+        <legendlayer drawingOrder="75" open="true" checked="Qt::Unchecked" name="conduites impression 5000" showFeatureCount="0">
           <filegroup open="true" hidden="false">
             <legendlayerfile isInOverview="0" layerid="vw_pipe_schema20170306143352379179081243" visible="0"/>
           </filegroup>
@@ -734,7 +734,7 @@
             <legendlayerfile isInOverview="0" layerid="vw_pipe_schema_visibleitems20141127154708843" visible="0"/>
           </filegroup>
         </legendlayer>
-        <legendlayer drawingOrder="20" open="false" checked="Qt::Unchecked" name="Flèche conduite enfant -> parent" showFeatureCount="0">
+        <legendlayer drawingOrder="20" open="false" checked="Qt::Unchecked" name="Flèches conduite enfant -> parent" showFeatureCount="0">
           <filegroup open="false" hidden="false">
             <legendlayerfile isInOverview="0" layerid="pipe_child_parent20130417092030507" visible="0"/>
           </filegroup>
@@ -742,12 +742,12 @@
       </legendgroup>
     </legendgroup>
     <legendgroup open="true" checked="Qt::Checked" name="Annotations">
-      <legendlayer drawingOrder="21" open="false" checked="Qt::Checked" name="annotation - ligne" showFeatureCount="0">
+      <legendlayer drawingOrder="21" open="false" checked="Qt::Checked" name="annotations - ligne" showFeatureCount="0">
         <filegroup open="false" hidden="false">
           <legendlayerfile isInOverview="0" layerid="od_annotationline20131203095020365" visible="1"/>
         </filegroup>
       </legendlayer>
-      <legendlayer drawingOrder="22" open="false" checked="Qt::Checked" name="annotation - point" showFeatureCount="0">
+      <legendlayer drawingOrder="22" open="false" checked="Qt::Checked" name="annotations - point" showFeatureCount="0">
         <filegroup open="false" hidden="false">
           <legendlayerfile isInOverview="0" layerid="od_annotationpoint20131203095020392" visible="1"/>
         </filegroup>
@@ -1129,7 +1129,7 @@
       <ComposerMap followPreset="false" mapRotation="0" keepLayerSet="true" followPresetName="" id="1" previewMode="Render" drawCanvasItems="true">
         <Extent ymin="145174.34327699668938294" xmin="555252.08216445404104888" ymax="145586.84327741741435602" xmax="556077.08216529549099505"/>
         <LayerSet>
-          <Layer>printmap20130304110011400</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=Polygon table=&quot;qwat_od&quot;.&quot;printmap&quot; (geometry) sql=" name="folios">printmap20130304110011400</Layer>
         </LayerSet>
         <Grid/>
         <ComposerMapGrid rightAnnotationDirection="0" gridFramePenColor="0,0,0,255" show="0" bottomAnnotationPosition="1" annotationPrecision="3" showAnnotation="0" topFrameDivisions="0" uuid="{a5ffcd5f-75c9-4a4f-9c9e-bcd04a79ad90}" leftAnnotationDirection="0" topAnnotationPosition="1" rightAnnotationDisplay="0" offsetX="0" offsetY="0" rightFrameDivisions="0" gridStyle="0" annotationFontColor="0,0,0,255" intervalX="0" gridFrameSideFlags="15" intervalY="0" bottomAnnotationDirection="0" leftAnnotationDisplay="0" leftFrameDivisions="0" frameFillColor1="255,255,255,255" annotationExpression="" frameFillColor2="0,0,0,255" crossLength="3" gridFramePenThickness="0.5" bottomAnnotationDisplay="0" unit="0" topAnnotationDisplay="0" leftAnnotationPosition="1" blendMode="0" gridFrameStyle="0" rightAnnotationPosition="1" gridFrameWidth="2" name="Grid 1" annotationFormat="0" bottomFrameDivisions="0" topAnnotationDirection="0" frameAnnotationDistance="1">
@@ -1260,26 +1260,26 @@
       <ComposerMap followPreset="false" mapRotation="0" keepLayerSet="true" followPresetName="" id="0" previewMode="Render" drawCanvasItems="true">
         <Extent ymin="145378.57302560043171979" xmin="555539.58216474729124457" ymax="145545.23977577040204778" xmax="555789.58216500224079937"/>
         <LayerSet>
-          <Layer>vw_node_installation20150918153835436</Layer>
-          <Layer>subscriber20130304110011459</Layer>
-          <Layer>od_subscriber_reference20131206105928067</Layer>
-          <Layer>od_meter20131120073630165</Layer>
-          <Layer>od_meter_reference20140304165835390</Layer>
-          <Layer>valve20130304110011497</Layer>
-          <Layer>hydrant20130304110004848</Layer>
-          <Layer>od_part20140429113327995</Layer>
-          <Layer>node20130304110005126</Layer>
-          <Layer>od_crossing20141023083754327</Layer>
-          <Layer>conduites_copy20130709141244955</Layer>
-          <Layer>od_remote20150116100522170</Layer>
-          <Layer>od_annotationline20131203095020365</Layer>
-          <Layer>od_annotationpoint20131203095020392</Layer>
-          <Layer>dimension20130807094904783</Layer>
-          <Layer>od_dimension_orientation20131202111155806</Layer>
-          <Layer>printmap20130304110011400</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_installation&quot; (geometry) sql=" name="ouvrage">vw_node_installation20150918153835436</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_subscriber&quot; (geometry) sql=" name="abonnés">subscriber20130304110011459</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;subscriber_reference&quot; (geometry) sql=" name="abonnés - renvoi">od_subscriber_reference20131206105928067</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_meter&quot; (geometry) sql=" name="compteurs réseau">od_meter20131120073630165</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;meter_reference&quot; (geometry) sql=" name="Compteurs réseau - renvoi">od_meter_reference20140304165835390</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;valve&quot; (geometry) sql=" name="vannes">valve20130304110011497</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_hydrant&quot; (geometry) sql=" name="hydrantes">hydrant20130304110004848</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_part&quot; (geometry) sql=" name="Pièces d'installations">od_part20140429113327995</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;node&quot; (geometry) sql=" name="noeuds">node20130304110005126</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;crossing&quot; (geometry) sql=" name="croisements">od_crossing20141023083754327</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineStringZ table=&quot;qwat_od&quot;.&quot;pipe&quot; (geometry) sql=" name="conduites">conduites_copy20130709141244955</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=MultiLineString table=&quot;qwat_od&quot;.&quot;remote&quot; (geometry) sql=" name="télécommandes">od_remote20150116100522170</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;annotationline&quot; (geometry) sql=" name="annotations - ligne">od_annotationline20131203095020365</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_dr&quot;.&quot;annotationpoint&quot; (geometry) sql=" name="annotations - point">od_annotationpoint20131203095020392</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_distance&quot; (geometry) sql=" name="côtes distance">dimension20130807094904783</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_orientation&quot; (geometry) sql=" name="côtes orientation">od_dimension_orientation20131202111155806</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=Polygon table=&quot;qwat_od&quot;.&quot;printmap&quot; (geometry) sql=" name="folios">printmap20130304110011400</Layer>
         </LayerSet>
         <LayerStyles>
-          <LayerStyle layerid="conduites_copy20130709141244955">
+          <LayerStyle provider="postgres" layerid="conduites_copy20130709141244955" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineStringZ table=&quot;qwat_od&quot;.&quot;pipe&quot; (geometry) sql=" name="conduites">
             <qgis version="2.13.0-Master" minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -2580,7 +2580,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>1</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="dimension20130807094904783">
+          <LayerStyle provider="postgres" layerid="dimension20130807094904783" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_distance&quot; (geometry) sql=" name="côtes distance">
             <qgis version="2.13.0-Master" minimumScale="-4.65661e-10" maximumScale="501" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -2804,7 +2804,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>1</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="hydrant20130304110004848">
+          <LayerStyle provider="postgres" layerid="hydrant20130304110004848" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_hydrant&quot; (geometry) sql=" name="hydrantes">
             <qgis version="2.13.0-Master" minimumScale="0" maximumScale="10001" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -3270,7 +3270,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>0</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="node20130304110005126">
+          <LayerStyle provider="postgres" layerid="node20130304110005126" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;node&quot; (geometry) sql=" name="noeuds">
             <qgis version="2.13.0-Master" minimumScale="0" maximumScale="501" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -3718,7 +3718,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>0</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_annotationline20131203095020365">
+          <LayerStyle provider="postgres" layerid="od_annotationline20131203095020365" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;annotationline&quot; (geometry) sql=" name="annotations - ligne">
             <qgis version="2.13.0-Master" minimumScale="0" maximumScale="1001" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -3949,7 +3949,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>1</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_annotationpoint20131203095020392">
+          <LayerStyle provider="postgres" layerid="od_annotationpoint20131203095020392" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_dr&quot;.&quot;annotationpoint&quot; (geometry) sql=" name="annotations - point">
             <qgis version="2.13.0-Master" minimumScale="-4.65661e-10" maximumScale="1001" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -4182,7 +4182,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>0</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_crossing20141023083754327">
+          <LayerStyle provider="postgres" layerid="od_crossing20141023083754327" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;crossing&quot; (geometry) sql=" name="croisements">
             <qgis version="2.13.0-Master" minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -4538,7 +4538,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>0</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_dimension_orientation20131202111155806">
+          <LayerStyle provider="postgres" layerid="od_dimension_orientation20131202111155806" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_orientation&quot; (geometry) sql=" name="côtes orientation">
             <qgis version="2.13.0-Master" minimumScale="0" maximumScale="501" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -4757,7 +4757,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>1</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_meter20131120073630165">
+          <LayerStyle provider="postgres" layerid="od_meter20131120073630165" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_meter&quot; (geometry) sql=" name="compteurs réseau">
             <qgis version="2.13.0-Master" minimumScale="4" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -5135,7 +5135,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>0</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_meter_reference20140304165835390">
+          <LayerStyle provider="postgres" layerid="od_meter_reference20140304165835390" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;meter_reference&quot; (geometry) sql=" name="Compteurs réseau - renvoi">
             <qgis version="2.13.0-Master" minimumScale="0" maximumScale="3000" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -5386,7 +5386,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>0</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_part20140429113327995">
+          <LayerStyle provider="postgres" layerid="od_part20140429113327995" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_part&quot; (geometry) sql=" name="Pièces d'installations">
             <qgis version="2.13.0-Master" minimumScale="-4.65661e-10" maximumScale="1000" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="3.6" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="0" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -5905,7 +5905,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>0</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_remote20150116100522170">
+          <LayerStyle provider="postgres" layerid="od_remote20150116100522170" source="service='qwat' sslmode=disable key='id' srid=21781 type=MultiLineString table=&quot;qwat_od&quot;.&quot;remote&quot; (geometry) sql=" name="télécommandes">
             <qgis version="2.13.0-Master" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -6240,7 +6240,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>1</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_subscriber_reference20131206105928067">
+          <LayerStyle provider="postgres" layerid="od_subscriber_reference20131206105928067" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;subscriber_reference&quot; (geometry) sql=" name="abonnés - renvoi">
             <qgis version="2.13.0-Master" minimumScale="0" maximumScale="3000" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -6491,7 +6491,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>0</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="printmap20130304110011400">
+          <LayerStyle provider="postgres" layerid="printmap20130304110011400" source="service='qwat' sslmode=allow key='id' srid=21781 type=Polygon table=&quot;qwat_od&quot;.&quot;printmap&quot; (geometry) sql=" name="folios">
             <qgis version="2.13.0-Master" minimumScale="200" maximumScale="250000" simplifyDrawingHints="1" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -6873,7 +6873,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>2</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="subscriber20130304110011459">
+          <LayerStyle provider="postgres" layerid="subscriber20130304110011459" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_subscriber&quot; (geometry) sql=" name="abonnés">
             <qgis version="2.13.0-Master" minimumScale="4" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -7470,7 +7470,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>0</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="valve20130304110011497">
+          <LayerStyle provider="postgres" layerid="valve20130304110011497" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;valve&quot; (geometry) sql=" name="vannes">
             <qgis version="2.13.0-Master" minimumScale="-4.65661e-10" maximumScale="10001" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -8256,7 +8256,7 @@ def my_form_open(dialog, layer, feature):
               <layerGeometryType>0</layerGeometryType>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="vw_node_installation20150918153835436">
+          <LayerStyle provider="postgres" layerid="vw_node_installation20150918153835436" source="service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_installation&quot; (geometry) sql=" name="ouvrage">
             <qgis version="2.13.0-Master" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -9329,7 +9329,7 @@ def my_form_open(dialog, layer, feature):
       </ComposerMap>
       <customproperties/>
     </Composition>
-    <Atlas hideCoverage="false" coverageLayer="printmap20130304110011400" singleFile="false" filenamePattern=" 'folio_' ||  &quot;district_name&quot; || '_' || &quot;name&quot;" enabled="true" filterFeatures="false" sortFeatures="false" pageNameExpression=""/>
+    <Atlas hideCoverage="false" coverageLayer="printmap20130304110011400" singleFile="false" filenamePattern=" 'folio_' ||  &quot;district_name&quot; || '_' || &quot;name&quot;" enabled="true" coverageLayerName="folios" filterFeatures="false" coverageLayerProvider="postgres" sortFeatures="false" pageNameExpression="" coverageLayerSource="service='qwat' sslmode=allow key='id' srid=21781 type=Polygon table=&quot;qwat_od&quot;.&quot;printmap&quot; (geometry) sql="/>
   </Composer>
   <Composer title="A0" visible="0">
     <Composition resizeToContentsMarginLeft="0" snapping="0" showPages="1" guidesVisible="1" resizeToContentsMarginTop="0" worldFileMap="" alignmentSnap="1" printResolution="300" paperWidth="1030" gridVisible="1" snapGridOffsetX="0" smartGuides="1" snapGridOffsetY="0" resizeToContentsMarginRight="0" snapTolerancePixels="10" printAsRaster="1" generateWorldFile="0" paperHeight="914" numPages="1" snapGridResolution="10" resizeToContentsMarginBottom="0">
@@ -9471,7 +9471,7 @@ def my_form_open(dialog, layer, feature):
         <fillColor2 alpha="255" red="255" blue="255" green="255"/>
         <strokeColor alpha="255" red="0" blue="0" green="0"/>
         <textColor alpha="255" red="0" blue="0" green="0"/>
-        <ComposerItem pagey="130.6" page="1" id="" lastValidViewScaleFactor="6.65958" positionMode="4" positionLock="false" x="152.934" y="130.6" visibility="1" zValue="11" background="true" transparency="0" frameJoinStyle="miter" blendMode="0" width="24.3978" outlineWidth="0.2" excludeFromExports="0" uuid="{ba898829-7dc4-452c-9766-a487e8205cfa}" height="9" itemRotation="0" frame="false" pagex="152.934">
+        <ComposerItem pagey="130.6" page="1" id="" lastValidViewScaleFactor="6.65958" positionMode="4" positionLock="false" x="152.934" y="130.6" visibility="1" zValue="11" background="true" transparency="0" frameJoinStyle="miter" blendMode="0" width="24.4634" outlineWidth="0.2" excludeFromExports="0" uuid="{ba898829-7dc4-452c-9766-a487e8205cfa}" height="9" itemRotation="0" frame="false" pagex="152.934">
           <FrameColor alpha="255" red="0" blue="0" green="0"/>
           <BackgroundColor alpha="255" red="255" blue="255" green="255"/>
           <customproperties/>
@@ -9653,21 +9653,21 @@ def my_form_open(dialog, layer, feature):
       <ComposerMap followPreset="false" mapRotation="0" keepLayerSet="true" followPresetName="" id="0" previewMode="Cache" drawCanvasItems="true">
         <Extent ymin="140426.29129607175127603" xmin="557362.68987539270892739" ymax="144345.04317506882944144" xmax="562987.68988113012164831"/>
         <LayerSet>
-          <Layer>subscriber20130304110011459</Layer>
-          <Layer>od_subscriber_reference20131206105928067</Layer>
-          <Layer>od_meter20131120073630165</Layer>
-          <Layer>od_meter_reference20140304165835390</Layer>
-          <Layer>valve20130304110011497</Layer>
-          <Layer>hydrant20130304110004848</Layer>
-          <Layer>node20130304110005126</Layer>
-          <Layer>od_part20140429113327995</Layer>
-          <Layer>conduites_copy20130709141244955</Layer>
-          <Layer>od_crossing20141023083754327</Layer>
-          <Layer>od_annotationline20131203095020365</Layer>
-          <Layer>od_annotationpoint20131203095020392</Layer>
-          <Layer>dimension20130807094904783</Layer>
-          <Layer>od_dimension_orientation20131202111155806</Layer>
-          <Layer>printmap20130304110011400</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_subscriber&quot; (geometry) sql=" name="abonnés">subscriber20130304110011459</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;subscriber_reference&quot; (geometry) sql=" name="abonnés - renvoi">od_subscriber_reference20131206105928067</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_meter&quot; (geometry) sql=" name="compteurs réseau">od_meter20131120073630165</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;meter_reference&quot; (geometry) sql=" name="Compteurs réseau - renvoi">od_meter_reference20140304165835390</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;valve&quot; (geometry) sql=" name="vannes">valve20130304110011497</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_hydrant&quot; (geometry) sql=" name="hydrantes">hydrant20130304110004848</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;node&quot; (geometry) sql=" name="noeuds">node20130304110005126</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_part&quot; (geometry) sql=" name="Pièces d'installations">od_part20140429113327995</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineStringZ table=&quot;qwat_od&quot;.&quot;pipe&quot; (geometry) sql=" name="conduites">conduites_copy20130709141244955</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;crossing&quot; (geometry) sql=" name="croisements">od_crossing20141023083754327</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;annotationline&quot; (geometry) sql=" name="annotations - ligne">od_annotationline20131203095020365</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_dr&quot;.&quot;annotationpoint&quot; (geometry) sql=" name="annotations - point">od_annotationpoint20131203095020392</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_distance&quot; (geometry) sql=" name="côtes distance">dimension20130807094904783</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_orientation&quot; (geometry) sql=" name="côtes orientation">od_dimension_orientation20131202111155806</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=Polygon table=&quot;qwat_od&quot;.&quot;printmap&quot; (geometry) sql=" name="folios">printmap20130304110011400</Layer>
         </LayerSet>
         <Grid/>
         <ComposerMapGrid rightAnnotationDirection="0" gridFramePenColor="0,0,0,255" show="0" bottomAnnotationPosition="0" annotationPrecision="0" showAnnotation="1" topFrameDivisions="0" uuid="{7f671b61-cebd-44ad-8f03-04891c6f2d26}" leftAnnotationDirection="0" topAnnotationPosition="0" rightAnnotationDisplay="0" offsetX="0" offsetY="0" rightFrameDivisions="0" gridStyle="0" annotationFontColor="0,0,0,255" intervalX="0" gridFrameSideFlags="15" intervalY="0" bottomAnnotationDirection="1" leftAnnotationDisplay="0" leftFrameDivisions="0" frameFillColor1="255,255,255,255" annotationExpression="" frameFillColor2="0,0,0,255" crossLength="3" gridFramePenThickness="0.5" bottomAnnotationDisplay="0" unit="0" topAnnotationDisplay="0" leftAnnotationPosition="0" blendMode="0" gridFrameStyle="0" rightAnnotationPosition="0" gridFrameWidth="4" name="Grid 1" annotationFormat="0" bottomFrameDivisions="0" topAnnotationDirection="1" frameAnnotationDistance="1">
@@ -9822,7 +9822,7 @@ def my_form_open(dialog, layer, feature):
         <fillColor2 alpha="255" red="255" blue="255" green="255"/>
         <strokeColor alpha="255" red="0" blue="0" green="0"/>
         <textColor alpha="255" red="0" blue="0" green="0"/>
-        <ComposerItem pagey="25.5" page="1" id="" lastValidViewScaleFactor="6.65958" positionMode="4" positionLock="false" x="148.527" y="25.5" visibility="1" zValue="10" background="true" transparency="0" frameJoinStyle="miter" blendMode="0" width="46.02" outlineWidth="0.2" excludeFromExports="0" uuid="{ef994c02-5abc-4762-9c7a-e57c24fd8ea8}" height="9" itemRotation="0" frame="false" pagex="148.527">
+        <ComposerItem pagey="25.5" page="1" id="" lastValidViewScaleFactor="6.65958" positionMode="4" positionLock="false" x="148.527" y="25.5" visibility="1" zValue="10" background="true" transparency="0" frameJoinStyle="miter" blendMode="0" width="46.102" outlineWidth="0.2" excludeFromExports="0" uuid="{ef994c02-5abc-4762-9c7a-e57c24fd8ea8}" height="9" itemRotation="0" frame="false" pagex="148.527">
           <FrameColor alpha="255" red="0" blue="0" green="0"/>
           <BackgroundColor alpha="255" red="255" blue="255" green="255"/>
           <customproperties/>
@@ -9944,25 +9944,25 @@ def my_form_open(dialog, layer, feature):
       <ComposerMap followPreset="false" mapRotation="0" keepLayerSet="true" followPresetName="" id="0" previewMode="Cache" drawCanvasItems="true">
         <Extent ymin="137141.46842982753878459" xmin="554967.33877685014158487" ymax="137243.9684299319924321" xmax="555039.08877692325040698"/>
         <LayerSet>
-          <Layer>valve20130304110011497</Layer>
-          <Layer>od_meter20131120073630165</Layer>
-          <Layer>od_annotationpoint20131203095020392</Layer>
-          <Layer>hydrant20130304110004848</Layer>
-          <Layer>conduites_copy20130709141244955</Layer>
-          <Layer>od_annotationline20131203095020365</Layer>
-          <Layer>od_dimension_orientation20131202111155806</Layer>
-          <Layer>od_remote20150116100522170</Layer>
-          <Layer>subscriber20130304110011459</Layer>
-          <Layer>od_part20140429113327995</Layer>
-          <Layer>dimension20130807094904783</Layer>
-          <Layer>od_meter_reference20140304165835390</Layer>
-          <Layer>od_subscriber_reference20131206105928067</Layer>
-          <Layer>printmap20130304110011400</Layer>
-          <Layer>od_crossing20141023083754327</Layer>
-          <Layer>node20130304110005126</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;valve&quot; (geometry) sql=" name="vannes">valve20130304110011497</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_meter&quot; (geometry) sql=" name="compteurs réseau">od_meter20131120073630165</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_dr&quot;.&quot;annotationpoint&quot; (geometry) sql=" name="annotations - point">od_annotationpoint20131203095020392</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_hydrant&quot; (geometry) sql=" name="hydrantes">hydrant20130304110004848</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineStringZ table=&quot;qwat_od&quot;.&quot;pipe&quot; (geometry) sql=" name="conduites">conduites_copy20130709141244955</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;annotationline&quot; (geometry) sql=" name="annotations - ligne">od_annotationline20131203095020365</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_orientation&quot; (geometry) sql=" name="côtes orientation">od_dimension_orientation20131202111155806</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=MultiLineString table=&quot;qwat_od&quot;.&quot;remote&quot; (geometry) sql=" name="télécommandes">od_remote20150116100522170</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_subscriber&quot; (geometry) sql=" name="abonnés">subscriber20130304110011459</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_part&quot; (geometry) sql=" name="Pièces d'installations">od_part20140429113327995</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_distance&quot; (geometry) sql=" name="côtes distance">dimension20130807094904783</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;meter_reference&quot; (geometry) sql=" name="Compteurs réseau - renvoi">od_meter_reference20140304165835390</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;subscriber_reference&quot; (geometry) sql=" name="abonnés - renvoi">od_subscriber_reference20131206105928067</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=Polygon table=&quot;qwat_od&quot;.&quot;printmap&quot; (geometry) sql=" name="folios">printmap20130304110011400</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;crossing&quot; (geometry) sql=" name="croisements">od_crossing20141023083754327</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;node&quot; (geometry) sql=" name="noeuds">node20130304110005126</Layer>
         </LayerSet>
         <LayerStyles>
-          <LayerStyle layerid="conduites_copy20130709141244955">
+          <LayerStyle provider="postgres" layerid="conduites_copy20130709141244955" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineStringZ table=&quot;qwat_od&quot;.&quot;pipe&quot; (geometry) sql=" name="conduites">
             <qgis version="2.11.0-Master" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -11123,7 +11123,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="dimension20130807094904783">
+          <LayerStyle provider="postgres" layerid="dimension20130807094904783" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_distance&quot; (geometry) sql=" name="côtes distance">
             <qgis version="2.11.0-Master" minimumScale="-4.65661e-10" maximumScale="501" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -11341,7 +11341,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="hydrant20130304110004848">
+          <LayerStyle provider="postgres" layerid="hydrant20130304110004848" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_hydrant&quot; (geometry) sql=" name="hydrantes">
             <qgis version="2.11.0-Master" minimumScale="-4.65661e-10" maximumScale="10001" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -11742,7 +11742,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="node20130304110005126">
+          <LayerStyle provider="postgres" layerid="node20130304110005126" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;node&quot; (geometry) sql=" name="noeuds">
             <qgis version="2.11.0-Master" minimumScale="0" maximumScale="501" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -12170,7 +12170,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_annotationline20131203095020365">
+          <LayerStyle provider="postgres" layerid="od_annotationline20131203095020365" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;annotationline&quot; (geometry) sql=" name="annotations - ligne">
             <qgis version="2.11.0-Master" minimumScale="0" maximumScale="1001" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -12395,7 +12395,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_annotationpoint20131203095020392">
+          <LayerStyle provider="postgres" layerid="od_annotationpoint20131203095020392" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_dr&quot;.&quot;annotationpoint&quot; (geometry) sql=" name="annotations - point">
             <qgis version="2.11.0-Master" minimumScale="-4.65661e-10" maximumScale="1001" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -12622,7 +12622,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_crossing20141023083754327">
+          <LayerStyle provider="postgres" layerid="od_crossing20141023083754327" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;crossing&quot; (geometry) sql=" name="croisements">
             <qgis version="2.11.0-Master" minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -12972,7 +12972,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_dimension_orientation20131202111155806">
+          <LayerStyle provider="postgres" layerid="od_dimension_orientation20131202111155806" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_orientation&quot; (geometry) sql=" name="côtes orientation">
             <qgis version="2.11.0-Master" minimumScale="0" maximumScale="501" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -13185,7 +13185,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_meter20131120073630165">
+          <LayerStyle provider="postgres" layerid="od_meter20131120073630165" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_meter&quot; (geometry) sql=" name="compteurs réseau">
             <qgis version="2.11.0-Master" minimumScale="4" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -13511,7 +13511,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_meter_reference20140304165835390">
+          <LayerStyle provider="postgres" layerid="od_meter_reference20140304165835390" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;meter_reference&quot; (geometry) sql=" name="Compteurs réseau - renvoi">
             <qgis version="2.11.0-Master" minimumScale="0" maximumScale="3000" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -13759,7 +13759,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_part20140429113327995">
+          <LayerStyle provider="postgres" layerid="od_part20140429113327995" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_part&quot; (geometry) sql=" name="Pièces d'installations">
             <qgis version="2.11.0-Master" minimumScale="0" maximumScale="1000" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="3.6" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="0" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -14243,7 +14243,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_remote20150116100522170">
+          <LayerStyle provider="postgres" layerid="od_remote20150116100522170" source="service='qwat' sslmode=disable key='id' srid=21781 type=MultiLineString table=&quot;qwat_od&quot;.&quot;remote&quot; (geometry) sql=" name="télécommandes">
             <qgis version="2.11.0-Master" minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -14538,7 +14538,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="od_subscriber_reference20131206105928067">
+          <LayerStyle provider="postgres" layerid="od_subscriber_reference20131206105928067" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;subscriber_reference&quot; (geometry) sql=" name="abonnés - renvoi">
             <qgis version="2.11.0-Master" minimumScale="0" maximumScale="3000" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -14786,7 +14786,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="printmap20130304110011400">
+          <LayerStyle provider="postgres" layerid="printmap20130304110011400" source="service='qwat' sslmode=allow key='id' srid=21781 type=Polygon table=&quot;qwat_od&quot;.&quot;printmap&quot; (geometry) sql=" name="folios">
             <qgis version="2.11.0-Master" minimumScale="200" maximumScale="250000" simplifyDrawingHints="1" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -15137,7 +15137,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="subscriber20130304110011459">
+          <LayerStyle provider="postgres" layerid="subscriber20130304110011459" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_subscriber&quot; (geometry) sql=" name="abonnés">
             <qgis version="2.11.0-Master" minimumScale="4" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -15622,7 +15622,7 @@ def my_form_open(dialog, layer, feature):
               </conditionalstyles>
             </qgis>
           </LayerStyle>
-          <LayerStyle layerid="valve20130304110011497">
+          <LayerStyle provider="postgres" layerid="valve20130304110011497" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;valve&quot; (geometry) sql=" name="vannes">
             <qgis version="2.11.0-Master" minimumScale="-4.65661e-10" maximumScale="10001" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
               <edittypes>
                 <edittype widgetv2type="TextEdit" name="id">
@@ -16532,7 +16532,7 @@ def my_form_open(dialog, layer, feature):
         <fillColor2 alpha="255" red="255" blue="255" green="255"/>
         <strokeColor alpha="255" red="0" blue="0" green="0"/>
         <textColor alpha="255" red="0" blue="0" green="0"/>
-        <ComposerItem pagey="25.5" page="1" id="" lastValidViewScaleFactor="6.65958" positionMode="4" positionLock="false" x="132.031" y="25.5" visibility="1" zValue="9" background="true" transparency="0" frameJoinStyle="miter" blendMode="0" width="46.02" outlineWidth="0.2" excludeFromExports="0" uuid="{6f598429-cabf-4706-b52a-eaa1c461d09f}" height="9" itemRotation="0" frame="false" pagex="132.031">
+        <ComposerItem pagey="25.5" page="1" id="" lastValidViewScaleFactor="6.65958" positionMode="4" positionLock="false" x="132.031" y="25.5" visibility="1" zValue="9" background="true" transparency="0" frameJoinStyle="miter" blendMode="0" width="46.102" outlineWidth="0.2" excludeFromExports="0" uuid="{6f598429-cabf-4706-b52a-eaa1c461d09f}" height="9" itemRotation="0" frame="false" pagex="132.031">
           <FrameColor alpha="255" red="0" blue="0" green="0"/>
           <BackgroundColor alpha="255" red="255" blue="255" green="255"/>
           <customproperties/>
@@ -16646,20 +16646,20 @@ def my_form_open(dialog, layer, feature):
       <ComposerMap followPreset="false" mapRotation="0" keepLayerSet="true" followPresetName="" id="0" previewMode="Cache" drawCanvasItems="true">
         <Extent ymin="142599.08241754528717138" xmin="559670.13398864679038525" ymax="142670.83241761845420115" xmax="559772.63398875133134425"/>
         <LayerSet>
-          <Layer>hydrant20130304110004848</Layer>
-          <Layer>valve20130304110011497</Layer>
-          <Layer>leak20130821111917060</Layer>
-          <Layer>subscriber20130304110011459</Layer>
-          <Layer>od_subscriber_reference20131206105928067</Layer>
-          <Layer>od_meter20131120073630165</Layer>
-          <Layer>od_meter_reference20140304165835390</Layer>
-          <Layer>node20130304110005126</Layer>
-          <Layer>conduites_copy20130709141244955</Layer>
-          <Layer>od_annotationline20131203095020365</Layer>
-          <Layer>od_annotationpoint20131203095020392</Layer>
-          <Layer>dimension20130807094904783</Layer>
-          <Layer>od_dimension_orientation20131202111155806</Layer>
-          <Layer>printmap20130304110011400</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_hydrant&quot; (geometry) sql=" name="hydrantes">hydrant20130304110004848</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;valve&quot; (geometry) sql=" name="vannes">valve20130304110011497</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;leak&quot; (geometry) sql=" name="fuites">leak20130821111917060</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_subscriber&quot; (geometry) sql=" name="abonnés">subscriber20130304110011459</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;subscriber_reference&quot; (geometry) sql=" name="abonnés - renvoi">od_subscriber_reference20131206105928067</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;vw_element_meter&quot; (geometry) sql=" name="compteurs réseau">od_meter20131120073630165</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_od&quot;.&quot;meter_reference&quot; (geometry) sql=" name="Compteurs réseau - renvoi">od_meter_reference20140304165835390</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table=&quot;qwat_od&quot;.&quot;node&quot; (geometry) sql=" name="noeuds">node20130304110005126</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineStringZ table=&quot;qwat_od&quot;.&quot;pipe&quot; (geometry) sql=" name="conduites">conduites_copy20130709141244955</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;annotationline&quot; (geometry) sql=" name="annotations - ligne">od_annotationline20131203095020365</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=Point table=&quot;qwat_dr&quot;.&quot;annotationpoint&quot; (geometry) sql=" name="annotations - point">od_annotationpoint20131203095020392</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_distance&quot; (geometry) sql=" name="côtes distance">dimension20130807094904783</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table=&quot;qwat_dr&quot;.&quot;dimension_orientation&quot; (geometry) sql=" name="côtes orientation">od_dimension_orientation20131202111155806</Layer>
+          <Layer provider="postgres" source="service='qwat' sslmode=allow key='id' srid=21781 type=Polygon table=&quot;qwat_od&quot;.&quot;printmap&quot; (geometry) sql=" name="folios">printmap20130304110011400</Layer>
         </LayerSet>
         <Grid/>
         <ComposerMapGrid rightAnnotationDirection="0" gridFramePenColor="0,0,0,255" show="0" bottomAnnotationPosition="1" annotationPrecision="3" showAnnotation="0" topFrameDivisions="0" uuid="{f33b132a-e26f-4783-a43f-20adc4c40ec7}" leftAnnotationDirection="0" topAnnotationPosition="1" rightAnnotationDisplay="0" offsetX="0" offsetY="0" rightFrameDivisions="0" gridStyle="0" annotationFontColor="0,0,0,255" intervalX="0" gridFrameSideFlags="15" intervalY="0" bottomAnnotationDirection="0" leftAnnotationDisplay="0" leftFrameDivisions="0" frameFillColor1="255,255,255,255" annotationExpression="" frameFillColor2="0,0,0,255" crossLength="3" gridFramePenThickness="0.5" bottomAnnotationDisplay="0" unit="0" topAnnotationDisplay="0" leftAnnotationPosition="1" blendMode="0" gridFrameStyle="0" rightAnnotationPosition="1" gridFrameWidth="2" name="Grid 1" annotationFormat="0" bottomFrameDivisions="0" topAnnotationDirection="0" frameAnnotationDistance="1">
@@ -16853,7 +16853,7 @@ def my_form_open(dialog, layer, feature):
         <fillColor2 alpha="255" red="255" blue="255" green="255"/>
         <strokeColor alpha="255" red="0" blue="0" green="0"/>
         <textColor alpha="255" red="0" blue="0" green="0"/>
-        <ComposerItem pagey="730.652" page="1" id="" lastValidViewScaleFactor="-1" positionMode="0" positionLock="false" x="1297.85" y="730.652" visibility="1" zValue="9" background="false" transparency="0" frameJoinStyle="miter" blendMode="0" width="44.6" outlineWidth="0.3" excludeFromExports="0" uuid="{c018f42f-b5ae-4c21-bd19-4a2fa2d1c49b}" height="8.91975" itemRotation="0" frame="false" pagex="1297.85">
+        <ComposerItem pagey="730.652" page="1" id="" lastValidViewScaleFactor="-1" positionMode="0" positionLock="false" x="1297.85" y="730.652" visibility="1" zValue="9" background="false" transparency="0" frameJoinStyle="miter" blendMode="0" width="44.4891" outlineWidth="0.3" excludeFromExports="0" uuid="{c018f42f-b5ae-4c21-bd19-4a2fa2d1c49b}" height="8.91975" itemRotation="0" frame="false" pagex="1297.85">
           <FrameColor alpha="255" red="0" blue="0" green="0"/>
           <BackgroundColor alpha="255" red="255" blue="255" green="255"/>
           <customproperties/>
@@ -17024,7 +17024,7 @@ def my_form_open(dialog, layer, feature):
       </ComposerMap>
       <customproperties/>
     </Composition>
-    <Atlas hideCoverage="false" coverageLayer="printmap20130304110011400" singleFile="false" filenamePattern="'output_'||@atlas_featurenumber" enabled="true" filterFeatures="false" sortFeatures="false" pageNameExpression=""/>
+    <Atlas hideCoverage="false" coverageLayer="printmap20130304110011400" singleFile="false" filenamePattern="'output_'||@atlas_featurenumber" enabled="true" coverageLayerName="folios" filterFeatures="false" coverageLayerProvider="postgres" sortFeatures="false" pageNameExpression="" coverageLayerSource="service='qwat' sslmode=allow key='id' srid=21781 type=Polygon table=&quot;qwat_od&quot;.&quot;printmap&quot; (geometry) sql="/>
   </Composer>
   <Composer title="croquis abonné" visible="0">
     <Composition resizeToContentsMarginLeft="0" snapping="0" showPages="1" guidesVisible="1" resizeToContentsMarginTop="0" worldFileMap="" alignmentSnap="1" printResolution="300" paperWidth="210" gridVisible="0" snapGridOffsetX="0" smartGuides="1" snapGridOffsetY="0" resizeToContentsMarginRight="0" snapTolerancePixels="10" printAsRaster="0" generateWorldFile="0" paperHeight="297" numPages="1" snapGridResolution="10" resizeToContentsMarginBottom="0">
@@ -17132,7 +17132,7 @@ def my_form_open(dialog, layer, feature):
         <fillColor2 alpha="255" red="255" blue="255" green="255"/>
         <strokeColor alpha="255" red="0" blue="0" green="0"/>
         <textColor alpha="255" red="0" blue="0" green="0"/>
-        <ComposerItem pagey="45.2" page="1" id="" lastValidViewScaleFactor="6.65958" positionMode="0" positionLock="false" x="138.757" y="45.2" visibility="1" zValue="4" background="true" transparency="0" frameJoinStyle="miter" blendMode="0" width="46.02" outlineWidth="0.2" excludeFromExports="0" uuid="{229f2357-1e55-4278-bbb4-02da58b31d7d}" height="10" itemRotation="0" frame="true" pagex="138.757">
+        <ComposerItem pagey="45.2" page="1" id="" lastValidViewScaleFactor="6.65958" positionMode="0" positionLock="false" x="138.757" y="45.2" visibility="1" zValue="4" background="true" transparency="0" frameJoinStyle="miter" blendMode="0" width="46.102" outlineWidth="0.2" excludeFromExports="0" uuid="{229f2357-1e55-4278-bbb4-02da58b31d7d}" height="10" itemRotation="0" frame="true" pagex="138.757">
           <FrameColor alpha="255" red="0" blue="0" green="0"/>
           <BackgroundColor alpha="255" red="255" blue="255" green="255"/>
           <customproperties/>
@@ -17235,7 +17235,7 @@ def my_form_open(dialog, layer, feature):
     </Composition>
   </Composer>
   <projectlayers>
-    <maplayer simplifyAlgorithm="0" minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <id>IntersectIt_Lines20130618102142813</id>
       <datasource>memory?geometry=LineString&amp;crs=EPSG:21781&amp;index=yes&amp;field=id:string(255,0)&amp;field=type:string(255,0)&amp;field=x:double(20,5)&amp;field=y:double(20,5)&amp;field=observation:double(20,5)&amp;field=precision:double(20,5)</datasource>
       <keywordList>
@@ -17255,18 +17255,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">memory</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="type" expression=""/>
-        <default field="x" expression=""/>
-        <default field="y" expression=""/>
-        <default field="observation" expression=""/>
-        <default field="precision" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -17502,8 +17493,17 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="type" expression=""/>
+        <default field="x" expression=""/>
+        <default field="y" expression=""/>
+        <default field="observation" expression=""/>
+        <default field="precision" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <id>IntersectIt_Points20130618102143276</id>
       <datasource>memory?geometry=Point&amp;crs=EPSG:21781&amp;index=yes&amp;field=id:string(255,0)</datasource>
       <keywordList>
@@ -17523,13 +17523,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">memory</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -17754,6 +17750,7 @@ def my_form_open(dialog, layer, feature):
       <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
         <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
           <fontProperties description="Lato,10,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
         <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
           <layer pass="0" class="SimpleMarker" locked="0">
@@ -17819,6 +17816,10 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" type="raster" hasScaleBasedVisibilityFlag="0">
       <extent>
@@ -17956,7 +17957,7 @@ def my_form_open(dialog, layer, feature):
       </pipe>
       <blendMode>6</blendMode>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="3.6" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="0" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="3.6" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="0" scaleBasedLabelVisibilityFlag="0">
       <id>_cadinput_techical_snap_layer_20140203092715598</id>
       <datasource>memory?geometry=Point</datasource>
       <keywordList>
@@ -17976,11 +17977,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">memory</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults/>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -18076,8 +18075,10 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults/>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="100000" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="100000" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>537539.9375</xmin>
         <ymin>153788.671875</ymin>
@@ -18103,7 +18104,6 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="pipe_function_" targetFieldName="fk_function" memoryCache="1" joinLayerId="vl_pipe_function20130304110005186">
           <joinFieldsSubset>
@@ -18157,77 +18157,6 @@ def my_form_open(dialog, layer, feature):
       <expressionfields>
         <field typeName="int2" precision="0" expression="COALESCE( &quot;schema_force_visible&quot;,  &quot;pipe_function_schema_visible&quot;)" length="-1" type="2" comment="" name="__schema_visible"/>
       </expressionfields>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_parent" expression=""/>
-        <default field="fk_function" expression=""/>
-        <default field="fk_installmethod" expression=""/>
-        <default field="fk_material" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_bedding" expression=""/>
-        <default field="fk_protection" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_watertype" expression=""/>
-        <default field="fk_locationtype" expression=""/>
-        <default field="fk_folder" expression=""/>
-        <default field="year" expression=""/>
-        <default field="year_rehabilitation" expression=""/>
-        <default field="year_end" expression=""/>
-        <default field="tunnel_or_bridge" expression=""/>
-        <default field="pressure_nominal" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="_valve_count" expression=""/>
-        <default field="_valve_closed" expression=""/>
-        <default field="schema_force_visible" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="fk_node_a" expression=""/>
-        <default field="fk_node_b" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_length2d" expression=""/>
-        <default field="_length3d" expression=""/>
-        <default field="_diff_elevation" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="pipe_function_value_fr" expression=""/>
-        <default field="pipe_function_value_en" expression=""/>
-        <default field="pipe_function_value_ro" expression=""/>
-        <default field="pipe_function_schema_visible" expression=""/>
-        <default field="pipe_function_major" expression=""/>
-        <default field="pipe_protection_value_fr" expression=""/>
-        <default field="pipe_protection_value_en" expression=""/>
-        <default field="pipe_protection_value_ro" expression=""/>
-        <default field="pressurezone_name" expression=""/>
-        <default field="pressurezone_colorcode" expression=""/>
-        <default field="pipe_material_short_fr" expression=""/>
-        <default field="pipe_material_short_en" expression=""/>
-        <default field="pipe_material_short_ro" expression=""/>
-        <default field="pipe_material_value_fr" expression=""/>
-        <default field="pipe_material_value_en" expression=""/>
-        <default field="pipe_material_value_ro" expression=""/>
-        <default field="pipe_material__displayname_fr" expression=""/>
-        <default field="pipe_material__displayname_en" expression=""/>
-        <default field="pipe_material__displayname_ro" expression=""/>
-        <default field="pipe_material_diameter" expression=""/>
-        <default field="pipe_material_diameter_nominal" expression=""/>
-        <default field="pipe_material_diameter_external" expression=""/>
-        <default field="status_value_fr" expression=""/>
-        <default field="status_value_en" expression=""/>
-        <default field="status_value_ro" expression=""/>
-        <default field="status_active" expression=""/>
-        <default field="status_functional" expression=""/>
-        <default field="__schema_visible" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
         <map-layer-style name="DXF">
@@ -21320,7 +21249,7 @@ def my_form_open(dialog, layer, feature):
               <text-format placeDirectionSymbol="0" multilineAlign="0" rightDirectionSymbol=">" multilineHeight="1" plussign="0" addDirectionSymbol="0" leftDirectionSymbol="&lt;" formatNumbers="0" decimals="3" wrapChar="" reverseDirectionSymbol="0"/>
               <text-buffer bufferSize="1" bufferSizeMapUnitScale="0,0,0,0,0,0" bufferColor="255,255,255,255" bufferDraw="0" bufferBlendMode="0" bufferTransp="0" bufferSizeInMapUnits="0" bufferNoFill="0" bufferJoinStyle="64"/>
               <background shapeSizeUnits="1" shapeType="0" shapeSVGFile="" shapeOffsetX="0" shapeOffsetY="0" shapeBlendMode="0" shapeFillColor="255,255,255,255" shapeTransparency="0" shapeSizeMapUnitScale="0,0,0,0,0,0" shapeSizeType="0" shapeJoinStyle="64" shapeDraw="0" shapeBorderWidthUnits="1" shapeSizeX="0" shapeSizeY="0" shapeOffsetMapUnitScale="0,0,0,0,0,0" shapeRadiiX="0" shapeRadiiY="0" shapeOffsetUnits="1" shapeRotation="0" shapeBorderWidth="0" shapeBorderColor="128,128,128,255" shapeRotationType="0" shapeBorderWidthMapUnitScale="0,0,0,0,0,0" shapeRadiiMapUnitScale="0,0,0,0,0,0" shapeRadiiUnits="1"/>
-              <shadow shadowOffsetMapUnitScale="0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusUnits="1" shadowTransparency="30" shadowColor="0,0,0,255" shadowUnder="0" shadowScale="100" shadowOffsetDist="1" shadowDraw="0" shadowOffsetAngle="135" shadowRadius="1,5" shadowRadiusMapUnitScale="0,0,0,0,0,0" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetUnits="1"/>
+              <shadow shadowOffsetMapUnitScale="0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusUnits="1" shadowTransparency="30" shadowColor="0,0,0,255" shadowUnder="0" shadowScale="100" shadowOffsetDist="1" shadowDraw="0" shadowOffsetAngle="135" shadowRadius="0" shadowRadiusMapUnitScale="0,0,0,0,0,0" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetUnits="1"/>
               <placement repeatDistanceUnit="1" placement="2" maxCurvedCharAngleIn="20" repeatDistance="0" distInMapUnits="0" labelOffsetInMapUnits="1" xOffset="0" distMapUnitScale="0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" repeatDistanceMapUnitScale="0,0,0,0,0,0" centroidWhole="0" priority="5" yOffset="0" offsetType="0" placementFlags="14" centroidInside="0" dist="1" angleOffset="0" maxCurvedCharAngleOut="-20" fitInPolygonOnly="0" quadOffset="4" labelOffsetMapUnitScale="0,0,0,0,0,0"/>
               <rendering fontMinPixelSize="3" scaleMax="10000000" fontMaxPixelSize="10000" scaleMin="1" upsidedownLabels="0" limitNumLabels="0" obstacle="1" obstacleFactor="1" scaleVisibility="0" fontLimitPixelSize="0" mergeLines="0" obstacleType="0" labelPerPart="0" zIndex="0" maxNumLabels="2000" displayAll="0" minFeatureSize="4"/>
               <data-defined>
@@ -21338,7 +21267,7 @@ def my_form_open(dialog, layer, feature):
               <text-format placeDirectionSymbol="0" multilineAlign="0" rightDirectionSymbol=">" multilineHeight="1" plussign="0" addDirectionSymbol="0" leftDirectionSymbol="&lt;" formatNumbers="0" decimals="3" wrapChar="" reverseDirectionSymbol="0"/>
               <text-buffer bufferSize="1" bufferSizeMapUnitScale="0,0,0,0,0,0" bufferColor="255,255,255,255" bufferDraw="0" bufferBlendMode="0" bufferTransp="0" bufferSizeInMapUnits="0" bufferNoFill="0" bufferJoinStyle="64"/>
               <background shapeSizeUnits="1" shapeType="0" shapeSVGFile="" shapeOffsetX="0" shapeOffsetY="0" shapeBlendMode="0" shapeFillColor="255,255,255,255" shapeTransparency="0" shapeSizeMapUnitScale="0,0,0,0,0,0" shapeSizeType="0" shapeJoinStyle="64" shapeDraw="0" shapeBorderWidthUnits="1" shapeSizeX="0" shapeSizeY="0" shapeOffsetMapUnitScale="0,0,0,0,0,0" shapeRadiiX="0" shapeRadiiY="0" shapeOffsetUnits="1" shapeRotation="0" shapeBorderWidth="0" shapeBorderColor="128,128,128,255" shapeRotationType="0" shapeBorderWidthMapUnitScale="0,0,0,0,0,0" shapeRadiiMapUnitScale="0,0,0,0,0,0" shapeRadiiUnits="1"/>
-              <shadow shadowOffsetMapUnitScale="0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusUnits="1" shadowTransparency="30" shadowColor="0,0,0,255" shadowUnder="0" shadowScale="100" shadowOffsetDist="1" shadowDraw="0" shadowOffsetAngle="135" shadowRadius="1,5" shadowRadiusMapUnitScale="0,0,0,0,0,0" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetUnits="1"/>
+              <shadow shadowOffsetMapUnitScale="0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusUnits="1" shadowTransparency="30" shadowColor="0,0,0,255" shadowUnder="0" shadowScale="100" shadowOffsetDist="1" shadowDraw="0" shadowOffsetAngle="135" shadowRadius="0" shadowRadiusMapUnitScale="0,0,0,0,0,0" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetUnits="1"/>
               <placement repeatDistanceUnit="1" placement="2" maxCurvedCharAngleIn="20" repeatDistance="0" distInMapUnits="0" labelOffsetInMapUnits="1" xOffset="0" distMapUnitScale="0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" repeatDistanceMapUnitScale="0,0,0,0,0,0" centroidWhole="0" priority="5" yOffset="0" offsetType="0" placementFlags="14" centroidInside="0" dist="1" angleOffset="0" maxCurvedCharAngleOut="-20" fitInPolygonOnly="0" quadOffset="4" labelOffsetMapUnitScale="0,0,0,0,0,0"/>
               <rendering fontMinPixelSize="3" scaleMax="10000000" fontMaxPixelSize="10000" scaleMin="1" upsidedownLabels="0" limitNumLabels="0" obstacle="1" obstacleFactor="1" scaleVisibility="0" fontLimitPixelSize="0" mergeLines="0" obstacleType="0" labelPerPart="0" zIndex="0" maxNumLabels="2000" displayAll="0" minFeatureSize="8"/>
               <data-defined>
@@ -21355,7 +21284,7 @@ def my_form_open(dialog, layer, feature):
               <text-format placeDirectionSymbol="0" multilineAlign="0" rightDirectionSymbol=">" multilineHeight="1" plussign="0" addDirectionSymbol="0" leftDirectionSymbol="&lt;" formatNumbers="0" decimals="3" wrapChar="" reverseDirectionSymbol="0"/>
               <text-buffer bufferSize="1" bufferSizeMapUnitScale="0,0,0,0,0,0" bufferColor="255,255,255,255" bufferDraw="0" bufferBlendMode="0" bufferTransp="0" bufferSizeInMapUnits="0" bufferNoFill="0" bufferJoinStyle="64"/>
               <background shapeSizeUnits="1" shapeType="0" shapeSVGFile="" shapeOffsetX="0" shapeOffsetY="0" shapeBlendMode="0" shapeFillColor="255,255,255,255" shapeTransparency="0" shapeSizeMapUnitScale="0,0,0,0,0,0" shapeSizeType="0" shapeJoinStyle="64" shapeDraw="0" shapeBorderWidthUnits="1" shapeSizeX="0" shapeSizeY="0" shapeOffsetMapUnitScale="0,0,0,0,0,0" shapeRadiiX="0" shapeRadiiY="0" shapeOffsetUnits="1" shapeRotation="0" shapeBorderWidth="0" shapeBorderColor="128,128,128,255" shapeRotationType="0" shapeBorderWidthMapUnitScale="0,0,0,0,0,0" shapeRadiiMapUnitScale="0,0,0,0,0,0" shapeRadiiUnits="1"/>
-              <shadow shadowOffsetMapUnitScale="0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusUnits="1" shadowTransparency="30" shadowColor="0,0,0,255" shadowUnder="0" shadowScale="100" shadowOffsetDist="1" shadowDraw="0" shadowOffsetAngle="135" shadowRadius="1,5" shadowRadiusMapUnitScale="0,0,0,0,0,0" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetUnits="1"/>
+              <shadow shadowOffsetMapUnitScale="0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusUnits="1" shadowTransparency="30" shadowColor="0,0,0,255" shadowUnder="0" shadowScale="100" shadowOffsetDist="1" shadowDraw="0" shadowOffsetAngle="135" shadowRadius="0" shadowRadiusMapUnitScale="0,0,0,0,0,0" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetUnits="1"/>
               <placement repeatDistanceUnit="1" placement="2" maxCurvedCharAngleIn="20" repeatDistance="0" distInMapUnits="0" labelOffsetInMapUnits="1" xOffset="0" distMapUnitScale="0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" repeatDistanceMapUnitScale="0,0,0,0,0,0" centroidWhole="0" priority="5" yOffset="0" offsetType="0" placementFlags="14" centroidInside="0" dist="1" angleOffset="0" maxCurvedCharAngleOut="-20" fitInPolygonOnly="0" quadOffset="4" labelOffsetMapUnitScale="0,0,0,0,0,0"/>
               <rendering fontMinPixelSize="3" scaleMax="10000000" fontMaxPixelSize="10000" scaleMin="1" upsidedownLabels="0" limitNumLabels="0" obstacle="1" obstacleFactor="1" scaleVisibility="0" fontLimitPixelSize="0" mergeLines="0" obstacleType="0" labelPerPart="0" zIndex="2" maxNumLabels="2000" displayAll="0" minFeatureSize="10"/>
               <data-defined>
@@ -21372,7 +21301,7 @@ def my_form_open(dialog, layer, feature):
               <text-format placeDirectionSymbol="0" multilineAlign="0" rightDirectionSymbol=">" multilineHeight="1" plussign="0" addDirectionSymbol="0" leftDirectionSymbol="&lt;" formatNumbers="0" decimals="3" wrapChar="" reverseDirectionSymbol="0"/>
               <text-buffer bufferSize="1" bufferSizeMapUnitScale="0,0,0,0,0,0" bufferColor="255,255,255,255" bufferDraw="0" bufferBlendMode="0" bufferTransp="0" bufferSizeInMapUnits="0" bufferNoFill="0" bufferJoinStyle="64"/>
               <background shapeSizeUnits="1" shapeType="0" shapeSVGFile="" shapeOffsetX="0" shapeOffsetY="0" shapeBlendMode="0" shapeFillColor="255,255,255,255" shapeTransparency="0" shapeSizeMapUnitScale="0,0,0,0,0,0" shapeSizeType="0" shapeJoinStyle="64" shapeDraw="0" shapeBorderWidthUnits="1" shapeSizeX="0" shapeSizeY="0" shapeOffsetMapUnitScale="0,0,0,0,0,0" shapeRadiiX="0" shapeRadiiY="0" shapeOffsetUnits="1" shapeRotation="0" shapeBorderWidth="0" shapeBorderColor="128,128,128,255" shapeRotationType="0" shapeBorderWidthMapUnitScale="0,0,0,0,0,0" shapeRadiiMapUnitScale="0,0,0,0,0,0" shapeRadiiUnits="1"/>
-              <shadow shadowOffsetMapUnitScale="0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusUnits="1" shadowTransparency="30" shadowColor="0,0,0,255" shadowUnder="0" shadowScale="100" shadowOffsetDist="1" shadowDraw="0" shadowOffsetAngle="135" shadowRadius="1,5" shadowRadiusMapUnitScale="0,0,0,0,0,0" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetUnits="1"/>
+              <shadow shadowOffsetMapUnitScale="0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusUnits="1" shadowTransparency="30" shadowColor="0,0,0,255" shadowUnder="0" shadowScale="100" shadowOffsetDist="1" shadowDraw="0" shadowOffsetAngle="135" shadowRadius="0" shadowRadiusMapUnitScale="0,0,0,0,0,0" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetUnits="1"/>
               <placement repeatDistanceUnit="1" placement="2" maxCurvedCharAngleIn="20" repeatDistance="0" distInMapUnits="0" labelOffsetInMapUnits="1" xOffset="0" distMapUnitScale="0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" repeatDistanceMapUnitScale="0,0,0,0,0,0" centroidWhole="0" priority="5" yOffset="0" offsetType="0" placementFlags="14" centroidInside="0" dist="1" angleOffset="0" maxCurvedCharAngleOut="-20" fitInPolygonOnly="0" quadOffset="4" labelOffsetMapUnitScale="0,0,0,0,0,0"/>
               <rendering fontMinPixelSize="3" scaleMax="10000000" fontMaxPixelSize="10000" scaleMin="1" upsidedownLabels="0" limitNumLabels="0" obstacle="1" obstacleFactor="1" scaleVisibility="0" fontLimitPixelSize="0" mergeLines="0" obstacleType="0" labelPerPart="0" zIndex="0" maxNumLabels="2000" displayAll="0" minFeatureSize="10"/>
               <data-defined>
@@ -21389,7 +21318,7 @@ def my_form_open(dialog, layer, feature):
               <text-format placeDirectionSymbol="0" multilineAlign="0" rightDirectionSymbol=">" multilineHeight="1" plussign="0" addDirectionSymbol="0" leftDirectionSymbol="&lt;" formatNumbers="0" decimals="3" wrapChar="" reverseDirectionSymbol="0"/>
               <text-buffer bufferSize="1" bufferSizeMapUnitScale="0,0,0,0,0,0" bufferColor="255,255,255,255" bufferDraw="0" bufferBlendMode="0" bufferTransp="0" bufferSizeInMapUnits="0" bufferNoFill="0" bufferJoinStyle="64"/>
               <background shapeSizeUnits="1" shapeType="0" shapeSVGFile="" shapeOffsetX="0" shapeOffsetY="0" shapeBlendMode="0" shapeFillColor="255,255,255,255" shapeTransparency="0" shapeSizeMapUnitScale="0,0,0,0,0,0" shapeSizeType="0" shapeJoinStyle="64" shapeDraw="0" shapeBorderWidthUnits="1" shapeSizeX="0" shapeSizeY="0" shapeOffsetMapUnitScale="0,0,0,0,0,0" shapeRadiiX="0" shapeRadiiY="0" shapeOffsetUnits="1" shapeRotation="0" shapeBorderWidth="0" shapeBorderColor="128,128,128,255" shapeRotationType="0" shapeBorderWidthMapUnitScale="0,0,0,0,0,0" shapeRadiiMapUnitScale="0,0,0,0,0,0" shapeRadiiUnits="1"/>
-              <shadow shadowOffsetMapUnitScale="0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusUnits="1" shadowTransparency="30" shadowColor="0,0,0,255" shadowUnder="0" shadowScale="100" shadowOffsetDist="1" shadowDraw="0" shadowOffsetAngle="135" shadowRadius="1,5" shadowRadiusMapUnitScale="0,0,0,0,0,0" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetUnits="1"/>
+              <shadow shadowOffsetMapUnitScale="0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusUnits="1" shadowTransparency="30" shadowColor="0,0,0,255" shadowUnder="0" shadowScale="100" shadowOffsetDist="1" shadowDraw="0" shadowOffsetAngle="135" shadowRadius="0" shadowRadiusMapUnitScale="0,0,0,0,0,0" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetUnits="1"/>
               <placement repeatDistanceUnit="1" placement="2" maxCurvedCharAngleIn="20" repeatDistance="0" distInMapUnits="0" labelOffsetInMapUnits="1" xOffset="0" distMapUnitScale="0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" repeatDistanceMapUnitScale="0,0,0,0,0,0" centroidWhole="0" priority="5" yOffset="0" offsetType="0" placementFlags="14" centroidInside="0" dist="1" angleOffset="0" maxCurvedCharAngleOut="-20" fitInPolygonOnly="0" quadOffset="4" labelOffsetMapUnitScale="0,0,0,0,0,0"/>
               <rendering fontMinPixelSize="3" scaleMax="10000000" fontMaxPixelSize="10000" scaleMin="1" upsidedownLabels="0" limitNumLabels="0" obstacle="1" obstacleFactor="1" scaleVisibility="0" fontLimitPixelSize="0" mergeLines="0" obstacleType="0" labelPerPart="0" zIndex="0" maxNumLabels="2000" displayAll="0" minFeatureSize="10"/>
               <data-defined>
@@ -21828,8 +21757,80 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_parent" expression=""/>
+        <default field="fk_function" expression=""/>
+        <default field="fk_installmethod" expression=""/>
+        <default field="fk_material" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_bedding" expression=""/>
+        <default field="fk_protection" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_watertype" expression=""/>
+        <default field="fk_locationtype" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_rehabilitation" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="tunnel_or_bridge" expression=""/>
+        <default field="pressure_nominal" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="_valve_count" expression=""/>
+        <default field="_valve_closed" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="fk_node_a" expression=""/>
+        <default field="fk_node_b" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_length2d" expression=""/>
+        <default field="_length3d" expression=""/>
+        <default field="_diff_elevation" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="pipe_function_value_fr" expression=""/>
+        <default field="pipe_function_value_en" expression=""/>
+        <default field="pipe_function_value_ro" expression=""/>
+        <default field="pipe_function_schema_visible" expression=""/>
+        <default field="pipe_function_major" expression=""/>
+        <default field="pipe_protection_value_fr" expression=""/>
+        <default field="pipe_protection_value_en" expression=""/>
+        <default field="pipe_protection_value_ro" expression=""/>
+        <default field="pressurezone_name" expression=""/>
+        <default field="pressurezone_colorcode" expression=""/>
+        <default field="pipe_material_short_fr" expression=""/>
+        <default field="pipe_material_short_en" expression=""/>
+        <default field="pipe_material_short_ro" expression=""/>
+        <default field="pipe_material_value_fr" expression=""/>
+        <default field="pipe_material_value_en" expression=""/>
+        <default field="pipe_material_value_ro" expression=""/>
+        <default field="pipe_material__displayname_fr" expression=""/>
+        <default field="pipe_material__displayname_en" expression=""/>
+        <default field="pipe_material__displayname_ro" expression=""/>
+        <default field="pipe_material_diameter" expression=""/>
+        <default field="pipe_material_diameter_nominal" expression=""/>
+        <default field="pipe_material_diameter_external" expression=""/>
+        <default field="status_value_fr" expression=""/>
+        <default field="status_value_en" expression=""/>
+        <default field="status_value_ro" expression=""/>
+        <default field="status_active" expression=""/>
+        <default field="status_functional" expression=""/>
+        <default field="__schema_visible" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>516762.99462557397782803</xmin>
         <ymin>157493.93195224899682216</ymin>
@@ -21855,18 +21856,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="altitude" expression=""/>
-        <default field="fk_object_reference" expression=""/>
-        <default field="code" expression=""/>
-        <default field="measurement_campaign" expression=""/>
-        <default field="remark" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -22129,6 +22121,7 @@ def my_form_open(dialog, layer, feature):
       <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
         <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="0">
           <fontProperties description="Lato,10,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
         <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
           <layer pass="0" class="SimpleMarker" locked="0">
@@ -22206,8 +22199,17 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="fk_object_reference" expression=""/>
+        <default field="code" expression=""/>
+        <default field="measurement_campaign" expression=""/>
+        <default field="remark" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="501" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="501" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>551470.6875</xmin>
         <ymin>138126.671875</ymin>
@@ -22233,16 +22235,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="observation" expression=""/>
-        <default field="_calculation" expression=""/>
-        <default field="remark" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -22476,6 +22471,7 @@ def my_form_open(dialog, layer, feature):
       <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
         <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="501" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="1" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="0">
           <fontProperties description="Lato,10,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
         <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
           <layer pass="0" class="SimpleMarker" locked="0">
@@ -22549,6 +22545,13 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="observation" expression=""/>
+        <default field="_calculation" expression=""/>
+        <default field="remark" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>distributor20130304114719702</id>
@@ -22573,14 +22576,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="name" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -22621,8 +22619,13 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="name" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" readOnly="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>509281.38736426999093965</xmin>
         <ymin>150068.59390810900367796</ymin>
@@ -22648,29 +22651,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="name" expression=""/>
-        <default field="shortname" expression=""/>
-        <default field="zip" expression=""/>
-        <default field="land_registry" expression=""/>
-        <default field="prefix" expression=""/>
-        <default field="colorcode" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -22940,6 +22923,7 @@ def my_form_open(dialog, layer, feature):
       <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
         <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="0">
           <fontProperties description="Lato,10,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
         <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
           <layer pass="0" class="SimpleMarker" locked="0">
@@ -23039,8 +23023,28 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="name" expression=""/>
+        <default field="shortname" expression=""/>
+        <default field="zip" expression=""/>
+        <default field="land_registry" expression=""/>
+        <default field="prefix" expression=""/>
+        <default field="colorcode" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514006.4375</xmin>
         <ymin>156275.609375</ymin>
@@ -23068,18 +23072,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>identification</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="description" expression=""/>
-        <default field="date_start" expression=""/>
-        <default field="date_end" expression=""/>
-        <default field="geometry_polygon" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -23409,8 +23404,17 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="description" expression=""/>
+        <default field="date_start" expression=""/>
+        <default field="date_end" expression=""/>
+        <default field="geometry_polygon" expression=""/>
+      </defaults>
+      <previewExpression>identification</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="10001" simplifyDrawingHints="0" readOnly="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="10001" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>551514.06764131004456431</xmin>
         <ymin>136205.05549400000018068</ymin>
@@ -23436,77 +23440,11 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="status_" targetFieldName="fk_status" memoryCache="1" joinLayerId="vl_status20130304110011436"/>
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="_pipe_node_type" expression=""/>
-        <default field="_pipe_orientation" expression=""/>
-        <default field="_pipe_schema_visible" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_folder" expression=""/>
-        <default field="fk_locationtype" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_precisionalti" expression=""/>
-        <default field="fk_object_reference" expression=""/>
-        <default field="altitude" expression=""/>
-        <default field="year" expression=""/>
-        <default field="year_end" expression=""/>
-        <default field="orientation" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="schema_force_visible" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="fk_provider" expression=""/>
-        <default field="fk_model_sup" expression=""/>
-        <default field="fk_model_inf" expression=""/>
-        <default field="fk_material" expression=""/>
-        <default field="fk_output" expression=""/>
-        <default field="underground" expression=""/>
-        <default field="marked" expression=""/>
-        <default field="pressure_static" expression=""/>
-        <default field="pressure_dynamic" expression=""/>
-        <default field="flow" expression=""/>
-        <default field="observation_date" expression=""/>
-        <default field="observation_source" expression=""/>
-        <default field="status_vl_active" expression=""/>
-        <default field="status_short_fr" expression=""/>
-        <default field="status_short_en" expression=""/>
-        <default field="status_short_ro" expression=""/>
-        <default field="status_value_fr" expression=""/>
-        <default field="status_value_en" expression=""/>
-        <default field="status_value_ro" expression=""/>
-        <default field="status_description_fr" expression=""/>
-        <default field="status_description_en" expression=""/>
-        <default field="status_description_ro" expression=""/>
-        <default field="status_active" expression=""/>
-        <default field="status_functional" expression=""/>
-        <default field="status_code_sire" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -24135,6 +24073,72 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="fk_locationtype" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_precisionalti" expression=""/>
+        <default field="fk_object_reference" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="orientation" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="fk_provider" expression=""/>
+        <default field="fk_model_sup" expression=""/>
+        <default field="fk_model_inf" expression=""/>
+        <default field="fk_material" expression=""/>
+        <default field="fk_output" expression=""/>
+        <default field="underground" expression=""/>
+        <default field="marked" expression=""/>
+        <default field="pressure_static" expression=""/>
+        <default field="pressure_dynamic" expression=""/>
+        <default field="flow" expression=""/>
+        <default field="observation_date" expression=""/>
+        <default field="observation_source" expression=""/>
+        <default field="status_vl_active" expression=""/>
+        <default field="status_short_fr" expression=""/>
+        <default field="status_short_en" expression=""/>
+        <default field="status_short_ro" expression=""/>
+        <default field="status_value_fr" expression=""/>
+        <default field="status_value_en" expression=""/>
+        <default field="status_value_ro" expression=""/>
+        <default field="status_description_fr" expression=""/>
+        <default field="status_description_en" expression=""/>
+        <default field="status_description_ro" expression=""/>
+        <default field="status_active" expression=""/>
+        <default field="status_functional" expression=""/>
+        <default field="status_code_sire" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>hydrant_material20150925104534891</id>
@@ -24157,24 +24161,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="pressure_nominal" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -24249,6 +24238,21 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="pressure_nominal" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>hydrant_model_inf20160205143014472</id>
@@ -24272,23 +24276,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -24359,6 +24349,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>hydrant_model_sup20160205143014484</id>
@@ -24382,23 +24386,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -24469,6 +24459,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>hydrant_output20160205143014497</id>
@@ -24492,23 +24496,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -24579,6 +24569,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>hydrant_provider20130304110004893</id>
@@ -24603,23 +24607,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -24692,8 +24682,22 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="10001" simplifyDrawingHints="0" readOnly="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="10001" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <id>hydrantes_copy20160127124839887</id>
       <datasource>service='qwat' sslmode=allow key='id' srid=21781 type=PointZ table="qwat_od"."vw_element_hydrant" (geometry) sql=</datasource>
       <shortname>hydrantes copy</shortname>
@@ -24714,77 +24718,11 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="status_" targetFieldName="fk_status" memoryCache="1" joinLayerId="vl_status20130304110011436"/>
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="_pipe_node_type" expression=""/>
-        <default field="_pipe_orientation" expression=""/>
-        <default field="_pipe_schema_visible" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_folder" expression=""/>
-        <default field="fk_locationtype" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_precisionalti" expression=""/>
-        <default field="fk_object_reference" expression=""/>
-        <default field="altitude" expression=""/>
-        <default field="year" expression=""/>
-        <default field="year_end" expression=""/>
-        <default field="orientation" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="schema_force_visible" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="fk_provider" expression=""/>
-        <default field="fk_model_sup" expression=""/>
-        <default field="fk_model_inf" expression=""/>
-        <default field="fk_material" expression=""/>
-        <default field="fk_output" expression=""/>
-        <default field="underground" expression=""/>
-        <default field="marked" expression=""/>
-        <default field="pressure_static" expression=""/>
-        <default field="pressure_dynamic" expression=""/>
-        <default field="flow" expression=""/>
-        <default field="observation_date" expression=""/>
-        <default field="observation_source" expression=""/>
-        <default field="status_vl_active" expression=""/>
-        <default field="status_short_fr" expression=""/>
-        <default field="status_short_en" expression=""/>
-        <default field="status_short_ro" expression=""/>
-        <default field="status_value_fr" expression=""/>
-        <default field="status_value_en" expression=""/>
-        <default field="status_value_ro" expression=""/>
-        <default field="status_description_fr" expression=""/>
-        <default field="status_description_en" expression=""/>
-        <default field="status_description_ro" expression=""/>
-        <default field="status_active" expression=""/>
-        <default field="status_functional" expression=""/>
-        <default field="status_code_sire" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -25484,8 +25422,74 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="fk_locationtype" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_precisionalti" expression=""/>
+        <default field="fk_object_reference" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="orientation" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="fk_provider" expression=""/>
+        <default field="fk_model_sup" expression=""/>
+        <default field="fk_model_inf" expression=""/>
+        <default field="fk_material" expression=""/>
+        <default field="fk_output" expression=""/>
+        <default field="underground" expression=""/>
+        <default field="marked" expression=""/>
+        <default field="pressure_static" expression=""/>
+        <default field="pressure_dynamic" expression=""/>
+        <default field="flow" expression=""/>
+        <default field="observation_date" expression=""/>
+        <default field="observation_source" expression=""/>
+        <default field="status_vl_active" expression=""/>
+        <default field="status_short_fr" expression=""/>
+        <default field="status_short_en" expression=""/>
+        <default field="status_short_ro" expression=""/>
+        <default field="status_value_fr" expression=""/>
+        <default field="status_value_en" expression=""/>
+        <default field="status_value_ro" expression=""/>
+        <default field="status_description_fr" expression=""/>
+        <default field="status_description_en" expression=""/>
+        <default field="status_description_ro" expression=""/>
+        <default field="status_active" expression=""/>
+        <default field="status_functional" expression=""/>
+        <default field="status_code_sire" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="1" maximumScale="5000" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="1" maximumScale="5000" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>537550.84707020001951605</xmin>
         <ymin>153798.86400000000139698</ymin>
@@ -25497,7 +25501,7 @@ def my_form_open(dialog, layer, feature):
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>fuite</layername>
+      <layername>fuites</layername>
       <srs>
         <spatialrefsys>
           <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
@@ -25511,33 +25515,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression>COALESCE( "description", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_cause" expression=""/>
-        <default field="fk_pipe" expression=""/>
-        <default field="widespread_damage" expression=""/>
-        <default field="detection_date" expression=""/>
-        <default field="repair_date" expression=""/>
-        <default field="_repaired" expression=""/>
-        <default field="address" expression=""/>
-        <default field="pipe_replaced" expression=""/>
-        <default field="description" expression=""/>
-        <default field="repair" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -25962,6 +25942,30 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_cause" expression=""/>
+        <default field="fk_pipe" expression=""/>
+        <default field="widespread_damage" expression=""/>
+        <default field="detection_date" expression=""/>
+        <default field="repair_date" expression=""/>
+        <default field="_repaired" expression=""/>
+        <default field="address" expression=""/>
+        <default field="pipe_replaced" expression=""/>
+        <default field="description" expression=""/>
+        <default field="repair" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "description", '&lt;NULL>' )</previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>locationtype20150922082741813</id>
@@ -25984,23 +25988,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -26071,8 +26061,22 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="501" simplifyDrawingHints="0" readOnly="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="501" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>550787.6875</xmin>
         <ymin>136066</ymin>
@@ -26098,26 +26102,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="_pipe_node_type" expression=""/>
-        <default field="_pipe_orientation" expression=""/>
-        <default field="_pipe_schema_visible" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -26656,6 +26643,23 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>object_reference20150922083109152</id>
@@ -26678,23 +26682,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -26765,8 +26755,22 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1001" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1001" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>551109.9375</xmin>
         <ymin>136050.03125</ymin>
@@ -26778,7 +26782,7 @@ def my_form_open(dialog, layer, feature):
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>annotation - ligne</layername>
+      <layername>annotations - ligne</layername>
       <srs>
         <spatialrefsys>
           <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
@@ -26792,19 +26796,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="labelvisible" expression=""/>
-        <default field="text_size" expression=""/>
-        <default field="text_orientation" expression=""/>
-        <default field="annotation" expression=""/>
-        <default field="scale_1" expression=""/>
-        <default field="scale_2" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -27124,8 +27118,18 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="labelvisible" expression=""/>
+        <default field="text_size" expression=""/>
+        <default field="text_orientation" expression=""/>
+        <default field="annotation" expression=""/>
+        <default field="scale_1" expression=""/>
+        <default field="scale_2" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1001" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1001" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>550709.75</xmin>
         <ymin>136080.4375</ymin>
@@ -27137,7 +27141,7 @@ def my_form_open(dialog, layer, feature):
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>annotation - point</layername>
+      <layername>annotations - point</layername>
       <srs>
         <spatialrefsys>
           <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
@@ -27151,18 +27155,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="text_size" expression=""/>
-        <default field="text_orientation" expression=""/>
-        <default field="annotation" expression=""/>
-        <default field="scale_1" expression=""/>
-        <default field="scale_2" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -27483,8 +27478,17 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="text_size" expression=""/>
+        <default field="text_orientation" expression=""/>
+        <default field="annotation" expression=""/>
+        <default field="scale_1" expression=""/>
+        <default field="scale_2" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <id>od_cover20141219115626229</id>
       <datasource>service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table="qwat_od"."cover" (geometry) sql=</datasource>
       <keywordList>
@@ -27504,34 +27508,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_cover_type" expression=""/>
-        <default field="fk_installation" expression=""/>
-        <default field="year" expression=""/>
-        <default field="altitude" expression=""/>
-        <default field="circular" expression=""/>
-        <default field="form_dimension" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="geometry_polygon" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -27874,6 +27853,7 @@ def my_form_open(dialog, layer, feature):
       <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
         <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
           <fontProperties description="Lato,10,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
         <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
           <layer pass="0" class="SimpleMarker" locked="0">
@@ -27983,8 +27963,33 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_cover_type" expression=""/>
+        <default field="fk_installation" expression=""/>
+        <default field="year" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="circular" expression=""/>
+        <default field="form_dimension" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="geometry_polygon" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514556.3125</xmin>
         <ymin>156786.203125</ymin>
@@ -28010,23 +28015,11 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields>
         <field typeName="double precision" precision="-1" expression="CASE WHEN hide_pipe = 1 THEN _pipe2_angle ELSE _pipe1_angle END" length="-1" type="6" comment="" name="_used_angle"/>
       </expressionfields>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="disabled" expression=""/>
-        <default field="controled" expression=""/>
-        <default field="hide_pipe" expression=""/>
-        <default field="_pipe1_id" expression=""/>
-        <default field="_pipe2_id" expression=""/>
-        <default field="_pipe1_angle" expression=""/>
-        <default field="_pipe2_angle" expression=""/>
-        <default field="_used_angle" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -28475,8 +28468,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="disabled" expression=""/>
+        <default field="controled" expression=""/>
+        <default field="hide_pipe" expression=""/>
+        <default field="_pipe1_id" expression=""/>
+        <default field="_pipe2_id" expression=""/>
+        <default field="_pipe1_angle" expression=""/>
+        <default field="_pipe2_angle" expression=""/>
+        <default field="_used_angle" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="501" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="501" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <id>od_dimension_orientation20131202111155806</id>
       <datasource>service='qwat' sslmode=disable key='id' estimatedmetadata=true srid=21781 type=LineString table="qwat_dr"."dimension_orientation" (geometry) sql=</datasource>
       <keywordList>
@@ -28496,15 +28501,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="observation" expression=""/>
-        <default field="remark" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -28733,6 +28732,7 @@ def my_form_open(dialog, layer, feature):
       <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
         <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="501" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="1" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
           <fontProperties description="Lato,10,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
         <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
           <layer pass="0" class="SimpleMarker" locked="0">
@@ -28804,8 +28804,14 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="observation" expression=""/>
+        <default field="remark" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="4" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="4" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>551176.97799044998828322</xmin>
         <ymin>136562.87261264200787991</ymin>
@@ -28817,7 +28823,7 @@ def my_form_open(dialog, layer, feature):
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>compteur réseau</layername>
+      <layername>compteurs réseau</layername>
       <srs>
         <spatialrefsys>
           <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
@@ -28831,52 +28837,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="_pipe_node_type" expression=""/>
-        <default field="_pipe_orientation" expression=""/>
-        <default field="_pipe_schema_visible" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_folder" expression=""/>
-        <default field="fk_locationtype" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_precisionalti" expression=""/>
-        <default field="fk_object_reference" expression=""/>
-        <default field="altitude" expression=""/>
-        <default field="year" expression=""/>
-        <default field="year_end" expression=""/>
-        <default field="orientation" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="schema_force_visible" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="fk_pipe" expression=""/>
-        <default field="parcel" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -29253,6 +29216,7 @@ def my_form_open(dialog, layer, feature):
       <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
         <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="1" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="4">
           <fontProperties description="Lato,10,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
         <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
           <layer pass="0" class="SimpleMarker" locked="0">
@@ -29402,8 +29366,51 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="fk_locationtype" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_precisionalti" expression=""/>
+        <default field="fk_object_reference" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="orientation" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="fk_pipe" expression=""/>
+        <default field="parcel" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="3000" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="3000" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>554753.7682911369483918</xmin>
         <ymin>137276.73480761601240374</ymin>
@@ -29415,7 +29422,7 @@ def my_form_open(dialog, layer, feature):
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>Compteur réseau - renvoi</layername>
+      <layername>Compteurs réseau - renvoi</layername>
       <srs>
         <spatialrefsys>
           <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
@@ -29429,7 +29436,6 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="meter_" targetFieldName="fk_meter" memoryCache="1" joinLayerId="od_meter20131120073630165">
           <joinFieldsSubset>
@@ -29440,11 +29446,6 @@ def my_form_open(dialog, layer, feature):
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_meter" expression=""/>
-        <default field="meter_identification" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -29702,6 +29703,7 @@ def my_form_open(dialog, layer, feature):
       <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
         <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="3000" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="1" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
           <fontProperties description="Lato,10,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
         <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
           <layer pass="0" class="SimpleMarker" locked="0">
@@ -29774,8 +29776,14 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_meter" expression=""/>
+        <default field="meter_identification" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="3.6" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="0" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="3.6" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="0" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514006.4375</xmin>
         <ymin>156505.53125</ymin>
@@ -29801,26 +29809,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="_pipe_node_type" expression=""/>
-        <default field="_pipe_orientation" expression=""/>
-        <default field="_pipe_schema_visible" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -30200,8 +30191,25 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1000" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="3.6" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="0" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1000" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="3.6" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="0" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>537541.09799999999813735</xmin>
         <ymin>153780.17300000000977889</ymin>
@@ -30227,7 +30235,6 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="node_" targetFieldName="fk_node" memoryCache="1" joinLayerId="node20130304110005126">
           <joinFieldsSubset>
@@ -30241,48 +30248,6 @@ def my_form_open(dialog, layer, feature):
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="_pipe_node_type" expression=""/>
-        <default field="_pipe_orientation" expression=""/>
-        <default field="_pipe_schema_visible" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_folder" expression=""/>
-        <default field="fk_locationtype" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_precisionalti" expression=""/>
-        <default field="fk_object_reference" expression=""/>
-        <default field="altitude" expression=""/>
-        <default field="year" expression=""/>
-        <default field="year_end" expression=""/>
-        <default field="orientation" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="schema_force_visible" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="fk_part_type" expression=""/>
-        <default field="fk_pipe" expression=""/>
-      </defaults>
       <map-layer-style-manager current="install_parts">
         <map-layer-style name="install_parts"/>
       </map-layer-style-manager>
@@ -31196,8 +31161,51 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="fk_locationtype" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_precisionalti" expression=""/>
+        <default field="fk_object_reference" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="orientation" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="fk_part_type" expression=""/>
+        <default field="fk_pipe" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>552071.9375</xmin>
         <ymin>136360.78125</ymin>
@@ -31209,7 +31217,7 @@ def my_form_open(dialog, layer, feature):
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>télécommande</layername>
+      <layername>télécommandes</layername>
       <srs>
         <spatialrefsys>
           <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
@@ -31223,40 +31231,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_material" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="year" expression=""/>
-        <default field="origin" expression=""/>
-        <default field="destination" expression=""/>
-        <default field="folder" expression=""/>
-        <default field="plan" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -31705,8 +31682,39 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_material" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="year" expression=""/>
+        <default field="origin" expression=""/>
+        <default field="destination" expression=""/>
+        <default field="folder" expression=""/>
+        <default field="plan" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="3000" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="3000" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>551088.4375</xmin>
         <ymin>136098.6875</ymin>
@@ -31732,7 +31740,6 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="subscriber_" targetFieldName="fk_subscriber" memoryCache="1" joinLayerId="subscriber20130304110011459">
           <joinFieldsSubset>
@@ -31743,11 +31750,6 @@ def my_form_open(dialog, layer, feature):
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_subscriber" expression=""/>
-        <default field="subscriber_identification" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -32005,6 +32007,7 @@ def my_form_open(dialog, layer, feature):
       <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
         <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="3000" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="1" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
           <fontProperties description="Lato,10,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
         <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
           <layer pass="0" class="SimpleMarker" locked="0">
@@ -32077,8 +32080,14 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_subscriber" expression=""/>
+        <default field="subscriber_identification" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="100000" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="100000" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514283.01131736498791724</xmin>
         <ymin>157151.28781176501070149</ymin>
@@ -32091,7 +32100,7 @@ def my_form_open(dialog, layer, feature):
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ouvrage 5000</layername>
+      <layername>ouvrages 5000</layername>
       <srs>
         <spatialrefsys>
           <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
@@ -32105,7 +32114,6 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="status_" targetFieldName="fk_status" memoryCache="1" joinLayerId="vl_status20130304110011436">
           <joinFieldsSubset>
@@ -32116,109 +32124,6 @@ def my_form_open(dialog, layer, feature):
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="_pipe_node_type" expression=""/>
-        <default field="_pipe_orientation" expression=""/>
-        <default field="_pipe_schema_visible" expression=""/>
-        <default field="geometry" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_folder" expression=""/>
-        <default field="fk_locationtype" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_precisionalti" expression=""/>
-        <default field="fk_object_reference" expression=""/>
-        <default field="altitude" expression=""/>
-        <default field="year" expression=""/>
-        <default field="year_end" expression=""/>
-        <default field="orientation" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="schema_force_visible" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="installation_type" expression=""/>
-        <default field="name" expression=""/>
-        <default field="fk_parent" expression=""/>
-        <default field="fk_remote" expression=""/>
-        <default field="fk_watertype" expression=""/>
-        <default field="parcel" expression=""/>
-        <default field="eca" expression=""/>
-        <default field="open_water_surface" expression=""/>
-        <default field="geometry_polygon" expression=""/>
-        <default field="fk_source_type" expression=""/>
-        <default field="fk_source_quality" expression=""/>
-        <default field="flow_lowest" expression=""/>
-        <default field="flow_average" expression=""/>
-        <default field="flow_concession" expression=""/>
-        <default field="contract_end" expression=""/>
-        <default field="gathering_chamber" expression=""/>
-        <default field="fk_pump_type" expression=""/>
-        <default field="fk_pipe_in" expression=""/>
-        <default field="fk_pipe_out" expression=""/>
-        <default field="fk_pump_operating" expression=""/>
-        <default field="no_pumps" expression=""/>
-        <default field="rejected_flow" expression=""/>
-        <default field="manometric_height" expression=""/>
-        <default field="fk_overflow" expression=""/>
-        <default field="fk_tank_firestorage" expression=""/>
-        <default field="storage_total" expression=""/>
-        <default field="storage_supply" expression=""/>
-        <default field="storage_fire" expression=""/>
-        <default field="altitude_overflow" expression=""/>
-        <default field="altitude_apron" expression=""/>
-        <default field="height_max" expression=""/>
-        <default field="fire_valve" expression=""/>
-        <default field="fire_remote" expression=""/>
-        <default field="_litrepercm" expression=""/>
-        <default field="cistern1_fk_type" expression=""/>
-        <default field="cistern1_dimension_1" expression=""/>
-        <default field="cistern1_dimension_2" expression=""/>
-        <default field="cistern1_storage" expression=""/>
-        <default field="_cistern1_litrepercm" expression=""/>
-        <default field="cistern2_fk_type" expression=""/>
-        <default field="cistern2_dimension_1" expression=""/>
-        <default field="cistern2_dimension_2" expression=""/>
-        <default field="cistern2_storage" expression=""/>
-        <default field="_cistern2_litrepercm" expression=""/>
-        <default field="sanitization_uv" expression=""/>
-        <default field="sanitization_chlorine_liquid" expression=""/>
-        <default field="sanitization_chlorine_gazeous" expression=""/>
-        <default field="sanitization_ozone" expression=""/>
-        <default field="filtration_membrane" expression=""/>
-        <default field="filtration_sandorgravel" expression=""/>
-        <default field="flocculation" expression=""/>
-        <default field="activatedcharcoal" expression=""/>
-        <default field="settling" expression=""/>
-        <default field="treatment_capacity" expression=""/>
-        <default field="networkseparation" expression=""/>
-        <default field="flow_meter" expression=""/>
-        <default field="water_meter" expression=""/>
-        <default field="manometer" expression=""/>
-        <default field="depth" expression=""/>
-        <default field="no_valves" expression=""/>
-        <default field="fk_pressurecontrol_type" expression=""/>
-        <default field="status_active" expression=""/>
-        <default field="status_functional" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
         <map-layer-style name="automatic labeling">
@@ -34942,8 +34847,112 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="geometry" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="fk_locationtype" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_precisionalti" expression=""/>
+        <default field="fk_object_reference" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="orientation" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="installation_type" expression=""/>
+        <default field="name" expression=""/>
+        <default field="fk_parent" expression=""/>
+        <default field="fk_remote" expression=""/>
+        <default field="fk_watertype" expression=""/>
+        <default field="parcel" expression=""/>
+        <default field="eca" expression=""/>
+        <default field="open_water_surface" expression=""/>
+        <default field="geometry_polygon" expression=""/>
+        <default field="fk_source_type" expression=""/>
+        <default field="fk_source_quality" expression=""/>
+        <default field="flow_lowest" expression=""/>
+        <default field="flow_average" expression=""/>
+        <default field="flow_concession" expression=""/>
+        <default field="contract_end" expression=""/>
+        <default field="gathering_chamber" expression=""/>
+        <default field="fk_pump_type" expression=""/>
+        <default field="fk_pipe_in" expression=""/>
+        <default field="fk_pipe_out" expression=""/>
+        <default field="fk_pump_operating" expression=""/>
+        <default field="no_pumps" expression=""/>
+        <default field="rejected_flow" expression=""/>
+        <default field="manometric_height" expression=""/>
+        <default field="fk_overflow" expression=""/>
+        <default field="fk_tank_firestorage" expression=""/>
+        <default field="storage_total" expression=""/>
+        <default field="storage_supply" expression=""/>
+        <default field="storage_fire" expression=""/>
+        <default field="altitude_overflow" expression=""/>
+        <default field="altitude_apron" expression=""/>
+        <default field="height_max" expression=""/>
+        <default field="fire_valve" expression=""/>
+        <default field="fire_remote" expression=""/>
+        <default field="_litrepercm" expression=""/>
+        <default field="cistern1_fk_type" expression=""/>
+        <default field="cistern1_dimension_1" expression=""/>
+        <default field="cistern1_dimension_2" expression=""/>
+        <default field="cistern1_storage" expression=""/>
+        <default field="_cistern1_litrepercm" expression=""/>
+        <default field="cistern2_fk_type" expression=""/>
+        <default field="cistern2_dimension_1" expression=""/>
+        <default field="cistern2_dimension_2" expression=""/>
+        <default field="cistern2_storage" expression=""/>
+        <default field="_cistern2_litrepercm" expression=""/>
+        <default field="sanitization_uv" expression=""/>
+        <default field="sanitization_chlorine_liquid" expression=""/>
+        <default field="sanitization_chlorine_gazeous" expression=""/>
+        <default field="sanitization_ozone" expression=""/>
+        <default field="filtration_membrane" expression=""/>
+        <default field="filtration_sandorgravel" expression=""/>
+        <default field="flocculation" expression=""/>
+        <default field="activatedcharcoal" expression=""/>
+        <default field="settling" expression=""/>
+        <default field="treatment_capacity" expression=""/>
+        <default field="networkseparation" expression=""/>
+        <default field="flow_meter" expression=""/>
+        <default field="water_meter" expression=""/>
+        <default field="manometer" expression=""/>
+        <default field="depth" expression=""/>
+        <default field="no_valves" expression=""/>
+        <default field="fk_pressurecontrol_type" expression=""/>
+        <default field="status_active" expression=""/>
+        <default field="status_functional" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1500" simplifyDrawingHints="1" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1500" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514567.3932959740050137</xmin>
         <ymin>156656.62448084400966763</ymin>
@@ -34955,7 +34964,7 @@ def my_form_open(dialog, layer, feature):
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>Flèche conduite enfant -> parent</layername>
+      <layername>Flèches conduite enfant -> parent</layername>
       <srs>
         <spatialrefsys>
           <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
@@ -34969,14 +34978,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="child" expression=""/>
-        <default field="parent" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -35322,6 +35326,11 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="child" expression=""/>
+        <default field="parent" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>pressurecontrol_type20150203100321270</id>
@@ -35344,23 +35353,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -35433,8 +35428,22 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" readOnly="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>512808.8792523110168986</xmin>
         <ymin>154882.74452505301451311</ymin>
@@ -35460,7 +35469,6 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="consumptionzone_" targetFieldName="fk_consumptionzone" memoryCache="1" joinLayerId="vw_consumptionzone20150508135647750">
           <joinFieldsSubset>
@@ -35471,33 +35479,6 @@ def my_form_open(dialog, layer, feature):
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_consumptionzone" expression=""/>
-        <default field="name" expression=""/>
-        <default field="population" expression=""/>
-        <default field="subscriber" expression=""/>
-        <default field="colorcode" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="consumptionzone_name" expression=""/>
-        <default field="consumptionzone_colorcode" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -36032,8 +36013,36 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_consumptionzone" expression=""/>
+        <default field="name" expression=""/>
+        <default field="population" expression=""/>
+        <default field="subscriber" expression=""/>
+        <default field="colorcode" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="consumptionzone_name" expression=""/>
+        <default field="consumptionzone_colorcode" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="200" maximumScale="250000" simplifyDrawingHints="1" readOnly="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="200" maximumScale="250000" simplifyDrawingHints="1" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514162.375</xmin>
         <ymin>156072.875</ymin>
@@ -36059,49 +36068,11 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="district_" targetFieldName="fk_district" memoryCache="1" joinLayerId="district20130304110004764"/>
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="name" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="version_date" expression=""/>
-        <default field="x_min" expression=""/>
-        <default field="y_min" expression=""/>
-        <default field="x_max" expression=""/>
-        <default field="y_max" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="district_name" expression=""/>
-        <default field="district_shortname" expression=""/>
-        <default field="district_zip" expression=""/>
-        <default field="district_land_registry" expression=""/>
-        <default field="district_prefix" expression=""/>
-        <default field="district_colorcode" expression=""/>
-        <default field="district_label_1_visible" expression=""/>
-        <default field="district_label_1_x" expression=""/>
-        <default field="district_label_1_y" expression=""/>
-        <default field="district_label_1_rotation" expression=""/>
-        <default field="district_label_1_text" expression=""/>
-        <default field="district_label_2_visible" expression=""/>
-        <default field="district_label_2_x" expression=""/>
-        <default field="district_label_2_y" expression=""/>
-        <default field="district_label_2_rotation" expression=""/>
-        <default field="district_label_2_text" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -36120,6 +36091,9 @@ def my_form_open(dialog, layer, feature):
         </edittype>
         <edittype widgetv2type="DateTime" name="version_date">
           <widgetv2config fieldEditable="1" calendar_popup="0" allow_null="0" display_format="yyyy-MM-dd" field_format="yyyy-MM-dd" constraint="" labelOnTop="0" constraintDescription="" notNull="0"/>
+        </edittype>
+        <edittype widgetv2type="TextEdit" name="print_scale">
+          <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
         </edittype>
         <edittype widgetv2type="TextEdit" name="x_min">
           <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
@@ -36512,36 +36486,37 @@ def my_form_open(dialog, layer, feature):
         <alias field="fk_district" index="2" name="Commune"/>
         <alias field="remark" index="3" name="Remarques"/>
         <alias field="version_date" index="4" name="Date MAJ"/>
-        <alias field="x_min" index="5" name=""/>
-        <alias field="y_min" index="6" name=""/>
-        <alias field="x_max" index="7" name=""/>
-        <alias field="y_max" index="8" name=""/>
-        <alias field="label_1_visible" index="9" name=""/>
-        <alias field="label_1_x" index="10" name=""/>
-        <alias field="label_1_y" index="11" name=""/>
-        <alias field="label_1_rotation" index="12" name=""/>
-        <alias field="label_1_text" index="13" name=""/>
-        <alias field="label_2_visible" index="14" name=""/>
-        <alias field="label_2_x" index="15" name=""/>
-        <alias field="label_2_y" index="16" name=""/>
-        <alias field="label_2_rotation" index="17" name=""/>
-        <alias field="label_2_text" index="18" name=""/>
-        <alias field="district_name" index="19" name=""/>
-        <alias field="district_shortname" index="20" name=""/>
-        <alias field="district_zip" index="21" name=""/>
-        <alias field="district_land_registry" index="22" name=""/>
-        <alias field="district_prefix" index="23" name=""/>
-        <alias field="district_colorcode" index="24" name=""/>
-        <alias field="district_label_1_visible" index="25" name=""/>
-        <alias field="district_label_1_x" index="26" name=""/>
-        <alias field="district_label_1_y" index="27" name=""/>
-        <alias field="district_label_1_rotation" index="28" name=""/>
-        <alias field="district_label_1_text" index="29" name=""/>
-        <alias field="district_label_2_visible" index="30" name=""/>
-        <alias field="district_label_2_x" index="31" name=""/>
-        <alias field="district_label_2_y" index="32" name=""/>
-        <alias field="district_label_2_rotation" index="33" name=""/>
-        <alias field="district_label_2_text" index="34" name=""/>
+        <alias field="print_scale" index="5" name=""/>
+        <alias field="x_min" index="6" name=""/>
+        <alias field="y_min" index="7" name=""/>
+        <alias field="x_max" index="8" name=""/>
+        <alias field="y_max" index="9" name=""/>
+        <alias field="label_1_visible" index="10" name=""/>
+        <alias field="label_1_x" index="11" name=""/>
+        <alias field="label_1_y" index="12" name=""/>
+        <alias field="label_1_rotation" index="13" name=""/>
+        <alias field="label_1_text" index="14" name=""/>
+        <alias field="label_2_visible" index="15" name=""/>
+        <alias field="label_2_x" index="16" name=""/>
+        <alias field="label_2_y" index="17" name=""/>
+        <alias field="label_2_rotation" index="18" name=""/>
+        <alias field="label_2_text" index="19" name=""/>
+        <alias field="district_name" index="20" name=""/>
+        <alias field="district_shortname" index="21" name=""/>
+        <alias field="district_zip" index="22" name=""/>
+        <alias field="district_land_registry" index="23" name=""/>
+        <alias field="district_prefix" index="24" name=""/>
+        <alias field="district_colorcode" index="25" name=""/>
+        <alias field="district_label_1_visible" index="26" name=""/>
+        <alias field="district_label_1_x" index="27" name=""/>
+        <alias field="district_label_1_y" index="28" name=""/>
+        <alias field="district_label_1_rotation" index="29" name=""/>
+        <alias field="district_label_1_text" index="30" name=""/>
+        <alias field="district_label_2_visible" index="31" name=""/>
+        <alias field="district_label_2_x" index="32" name=""/>
+        <alias field="district_label_2_y" index="33" name=""/>
+        <alias field="district_label_2_rotation" index="34" name=""/>
+        <alias field="district_label_2_text" index="35" name=""/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
@@ -36616,8 +36591,47 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="name" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="version_date" expression=""/>
+        <default field="print_scale" expression=""/>
+        <default field="x_min" expression=""/>
+        <default field="y_min" expression=""/>
+        <default field="x_max" expression=""/>
+        <default field="y_max" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="district_name" expression=""/>
+        <default field="district_shortname" expression=""/>
+        <default field="district_zip" expression=""/>
+        <default field="district_land_registry" expression=""/>
+        <default field="district_prefix" expression=""/>
+        <default field="district_colorcode" expression=""/>
+        <default field="district_label_1_visible" expression=""/>
+        <default field="district_label_1_x" expression=""/>
+        <default field="district_label_1_y" expression=""/>
+        <default field="district_label_1_rotation" expression=""/>
+        <default field="district_label_1_text" expression=""/>
+        <default field="district_label_2_visible" expression=""/>
+        <default field="district_label_2_x" expression=""/>
+        <default field="district_label_2_y" expression=""/>
+        <default field="district_label_2_rotation" expression=""/>
+        <default field="district_label_2_text" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" readOnly="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>511790.25404516700655222</xmin>
         <ymin>154354.36257139401277527</ymin>
@@ -36643,18 +36657,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_type" expression=""/>
-        <default field="name" expression=""/>
-        <default field="validated" expression=""/>
-        <default field="date" expression=""/>
-        <default field="agent" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -36888,6 +36893,7 @@ def my_form_open(dialog, layer, feature):
       <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
         <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
           <fontProperties description="Lato,10,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
         <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
           <layer pass="0" class="SimpleMarker" locked="0">
@@ -36965,6 +36971,15 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_type" expression=""/>
+        <default field="name" expression=""/>
+        <default field="validated" expression=""/>
+        <default field="date" expression=""/>
+        <default field="agent" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>protectionzone_type20160205143014456</id>
@@ -36988,23 +37003,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -37075,6 +37076,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>pump_operating20150922083814587</id>
@@ -37097,24 +37112,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="code_sire" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -37189,6 +37189,21 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="code_sire" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>remote_type20130304110004987</id>
@@ -37213,23 +37228,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -37302,8 +37303,22 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="4" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="4" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>551159.01811429997906089</xmin>
         <ymin>136145.90337174601154402</ymin>
@@ -37329,7 +37344,6 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="district_" targetFieldName="fk_district" memoryCache="1" joinLayerId="district20130304110004764">
           <joinFieldsSubset>
@@ -37343,56 +37357,6 @@ def my_form_open(dialog, layer, feature):
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="_pipe_node_type" expression=""/>
-        <default field="_pipe_orientation" expression=""/>
-        <default field="_pipe_schema_visible" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_folder" expression=""/>
-        <default field="fk_locationtype" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_precisionalti" expression=""/>
-        <default field="fk_object_reference" expression=""/>
-        <default field="altitude" expression=""/>
-        <default field="year" expression=""/>
-        <default field="year_end" expression=""/>
-        <default field="orientation" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="schema_force_visible" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="fk_subscriber_type" expression=""/>
-        <default field="fk_pipe" expression=""/>
-        <default field="parcel" expression=""/>
-        <default field="flow_current" expression=""/>
-        <default field="flow_planned" expression=""/>
-        <default field="district_name" expression=""/>
-        <default field="district_shortname" expression=""/>
-        <default field="district_zip" expression=""/>
-        <default field="district_land_registry" expression=""/>
-        <default field="district_prefix" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -38142,8 +38106,59 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="fk_locationtype" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_precisionalti" expression=""/>
+        <default field="fk_object_reference" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="orientation" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="fk_subscriber_type" expression=""/>
+        <default field="fk_pipe" expression=""/>
+        <default field="parcel" expression=""/>
+        <default field="flow_current" expression=""/>
+        <default field="flow_planned" expression=""/>
+        <default field="district_name" expression=""/>
+        <default field="district_shortname" expression=""/>
+        <default field="district_zip" expression=""/>
+        <default field="district_land_registry" expression=""/>
+        <default field="district_prefix" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514382.26254942297236994</xmin>
         <ymin>156519.32857683100155555</ymin>
@@ -38169,14 +38184,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="identification" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -38471,8 +38481,13 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="identification" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514025.66549615800613537</xmin>
         <ymin>156849.13075657899025828</ymin>
@@ -38499,40 +38514,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_material" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="year" expression=""/>
-        <default field="origin" expression=""/>
-        <default field="destination" expression=""/>
-        <default field="folder" expression=""/>
-        <default field="plan" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="geometry" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -38981,8 +38965,39 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_material" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="year" expression=""/>
+        <default field="origin" expression=""/>
+        <default field="destination" expression=""/>
+        <default field="folder" expression=""/>
+        <default field="plan" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="geometry" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="1" maximumScale="10001" simplifyDrawingHints="0" readOnly="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="1" maximumScale="10001" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="1" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>551073.15025410999078304</xmin>
         <ymin>136174.07603932998608798</ymin>
@@ -39008,7 +39023,6 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="valve_function_" targetFieldName="fk_valve_function" memoryCache="1" joinLayerId="vl_valve_function20130304110011544"/>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="valve_type_" targetFieldName="fk_valve_type" memoryCache="1" joinLayerId="vl_valve_type20130304110011685"/>
@@ -39031,87 +39045,6 @@ def my_form_open(dialog, layer, feature):
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_valve_type" expression=""/>
-        <default field="fk_valve_function" expression=""/>
-        <default field="fk_valve_actuation" expression=""/>
-        <default field="fk_pipe" expression=""/>
-        <default field="fk_handle_precision" expression=""/>
-        <default field="fk_handle_precisionalti" expression=""/>
-        <default field="fk_maintenance" expression=""/>
-        <default field="diameter_nominal" expression=""/>
-        <default field="closed" expression=""/>
-        <default field="networkseparation" expression=""/>
-        <default field="handle_altitude" expression=""/>
-        <default field="handle_geometry" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_precisionalti" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_object_reference" expression=""/>
-        <default field="fk_folder" expression=""/>
-        <default field="year" expression=""/>
-        <default field="year_end" expression=""/>
-        <default field="altitude" expression=""/>
-        <default field="orientation" expression=""/>
-        <default field="fk_locationtype" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="_pipe_node_type" expression=""/>
-        <default field="_pipe_orientation" expression=""/>
-        <default field="_pipe_schema_visible" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="schema_force_visible" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="valve_function_vl_active" expression=""/>
-        <default field="valve_function_short_fr" expression=""/>
-        <default field="valve_function_short_en" expression=""/>
-        <default field="valve_function_short_ro" expression=""/>
-        <default field="valve_function_value_fr" expression=""/>
-        <default field="valve_function_value_en" expression=""/>
-        <default field="valve_function_value_ro" expression=""/>
-        <default field="valve_function_description_fr" expression=""/>
-        <default field="valve_function_description_en" expression=""/>
-        <default field="valve_function_description_ro" expression=""/>
-        <default field="valve_function_schema_visible" expression=""/>
-        <default field="valve_type_vl_active" expression=""/>
-        <default field="valve_type_short_fr" expression=""/>
-        <default field="valve_type_short_en" expression=""/>
-        <default field="valve_type_short_ro" expression=""/>
-        <default field="valve_type_value_fr" expression=""/>
-        <default field="valve_type_value_en" expression=""/>
-        <default field="valve_type_value_ro" expression=""/>
-        <default field="valve_type_description_fr" expression=""/>
-        <default field="valve_type_description_en" expression=""/>
-        <default field="valve_type_description_ro" expression=""/>
-        <default field="valve_actuation_id" expression=""/>
-        <default field="valve_actuation_vl_active" expression=""/>
-        <default field="valve_actuation_short_fr" expression=""/>
-        <default field="valve_actuation_value_fr" expression=""/>
-        <default field="valve_actuation_description_fr" expression=""/>
-        <default field="valve_actuation_schema_visible" expression=""/>
-        <default field="status_active" expression=""/>
-        <default field="status_functional" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
         <map-layer-style name="DXF">
@@ -41010,6 +40943,88 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_valve_type" expression=""/>
+        <default field="fk_valve_function" expression=""/>
+        <default field="fk_valve_actuation" expression=""/>
+        <default field="fk_pipe" expression=""/>
+        <default field="fk_handle_precision" expression=""/>
+        <default field="fk_handle_precisionalti" expression=""/>
+        <default field="fk_maintenance" expression=""/>
+        <default field="diameter_nominal" expression=""/>
+        <default field="closed" expression=""/>
+        <default field="networkseparation" expression=""/>
+        <default field="handle_altitude" expression=""/>
+        <default field="handle_geometry" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_precisionalti" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_object_reference" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="orientation" expression=""/>
+        <default field="fk_locationtype" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="valve_function_vl_active" expression=""/>
+        <default field="valve_function_short_fr" expression=""/>
+        <default field="valve_function_short_en" expression=""/>
+        <default field="valve_function_short_ro" expression=""/>
+        <default field="valve_function_value_fr" expression=""/>
+        <default field="valve_function_value_en" expression=""/>
+        <default field="valve_function_value_ro" expression=""/>
+        <default field="valve_function_description_fr" expression=""/>
+        <default field="valve_function_description_en" expression=""/>
+        <default field="valve_function_description_ro" expression=""/>
+        <default field="valve_function_schema_visible" expression=""/>
+        <default field="valve_type_vl_active" expression=""/>
+        <default field="valve_type_short_fr" expression=""/>
+        <default field="valve_type_short_en" expression=""/>
+        <default field="valve_type_short_ro" expression=""/>
+        <default field="valve_type_value_fr" expression=""/>
+        <default field="valve_type_value_en" expression=""/>
+        <default field="valve_type_value_ro" expression=""/>
+        <default field="valve_type_description_fr" expression=""/>
+        <default field="valve_type_description_en" expression=""/>
+        <default field="valve_type_description_ro" expression=""/>
+        <default field="valve_actuation_id" expression=""/>
+        <default field="valve_actuation_vl_active" expression=""/>
+        <default field="valve_actuation_short_fr" expression=""/>
+        <default field="valve_actuation_value_fr" expression=""/>
+        <default field="valve_actuation_description_fr" expression=""/>
+        <default field="valve_actuation_schema_visible" expression=""/>
+        <default field="status_active" expression=""/>
+        <default field="status_functional" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>valve_actuation20150608112911022</id>
@@ -41032,24 +41047,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="schema_visible" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -41124,8 +41124,23 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="schema_visible" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="100000" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="100000" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514320.375</xmin>
         <ymin>156546.75</ymin>
@@ -41151,7 +41166,6 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="pipe_" targetFieldName="fk_pipe" memoryCache="1" joinLayerId="conduites_copy20130709141244955">
           <joinFieldsSubset>
@@ -41174,87 +41188,6 @@ def my_form_open(dialog, layer, feature):
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_valve_type" expression=""/>
-        <default field="fk_valve_function" expression=""/>
-        <default field="fk_valve_actuation" expression=""/>
-        <default field="fk_pipe" expression=""/>
-        <default field="fk_handle_precision" expression=""/>
-        <default field="fk_handle_precisionalti" expression=""/>
-        <default field="fk_maintenance" expression=""/>
-        <default field="diameter_nominal" expression=""/>
-        <default field="closed" expression=""/>
-        <default field="networkseparation" expression=""/>
-        <default field="handle_altitude" expression=""/>
-        <default field="handle_geometry" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_precisionalti" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_object_reference" expression=""/>
-        <default field="fk_folder" expression=""/>
-        <default field="year" expression=""/>
-        <default field="year_end" expression=""/>
-        <default field="altitude" expression=""/>
-        <default field="orientation" expression=""/>
-        <default field="fk_locationtype" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="_pipe_node_type" expression=""/>
-        <default field="_pipe_orientation" expression=""/>
-        <default field="_pipe_schema_visible" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="geometry" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="schema_force_visible" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="pipe_schema_force_visible" expression=""/>
-        <default field="pipe_pipe_function_schema_visible" expression=""/>
-        <default field="valve_function_vl_active" expression=""/>
-        <default field="valve_function_short_fr" expression=""/>
-        <default field="valve_function_short_en" expression=""/>
-        <default field="valve_function_short_ro" expression=""/>
-        <default field="valve_function_value_fr" expression=""/>
-        <default field="valve_function_value_en" expression=""/>
-        <default field="valve_function_value_ro" expression=""/>
-        <default field="valve_function_description_fr" expression=""/>
-        <default field="valve_function_description_en" expression=""/>
-        <default field="valve_function_description_ro" expression=""/>
-        <default field="valve_function_schema_visible" expression=""/>
-        <default field="valve_type_vl_active" expression=""/>
-        <default field="valve_type_short_fr" expression=""/>
-        <default field="valve_type_short_en" expression=""/>
-        <default field="valve_type_short_ro" expression=""/>
-        <default field="valve_type_value_fr" expression=""/>
-        <default field="valve_type_value_en" expression=""/>
-        <default field="valve_type_value_ro" expression=""/>
-        <default field="valve_type_description_fr" expression=""/>
-        <default field="valve_type_description_en" expression=""/>
-        <default field="valve_type_description_ro" expression=""/>
-        <default field="valve_actuation_id" expression=""/>
-        <default field="valve_actuation_vl_active" expression=""/>
-        <default field="valve_actuation_short_fr" expression=""/>
-        <default field="valve_actuation_value_fr" expression=""/>
-        <default field="valve_actuation_description_fr" expression=""/>
-        <default field="valve_actuation_schema_visible" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -42085,6 +42018,88 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_valve_type" expression=""/>
+        <default field="fk_valve_function" expression=""/>
+        <default field="fk_valve_actuation" expression=""/>
+        <default field="fk_pipe" expression=""/>
+        <default field="fk_handle_precision" expression=""/>
+        <default field="fk_handle_precisionalti" expression=""/>
+        <default field="fk_maintenance" expression=""/>
+        <default field="diameter_nominal" expression=""/>
+        <default field="closed" expression=""/>
+        <default field="networkseparation" expression=""/>
+        <default field="handle_altitude" expression=""/>
+        <default field="handle_geometry" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_precisionalti" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_object_reference" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="orientation" expression=""/>
+        <default field="fk_locationtype" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="geometry" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="pipe_schema_force_visible" expression=""/>
+        <default field="pipe_pipe_function_schema_visible" expression=""/>
+        <default field="valve_function_vl_active" expression=""/>
+        <default field="valve_function_short_fr" expression=""/>
+        <default field="valve_function_short_en" expression=""/>
+        <default field="valve_function_short_ro" expression=""/>
+        <default field="valve_function_value_fr" expression=""/>
+        <default field="valve_function_value_en" expression=""/>
+        <default field="valve_function_value_ro" expression=""/>
+        <default field="valve_function_description_fr" expression=""/>
+        <default field="valve_function_description_en" expression=""/>
+        <default field="valve_function_description_ro" expression=""/>
+        <default field="valve_function_schema_visible" expression=""/>
+        <default field="valve_type_vl_active" expression=""/>
+        <default field="valve_type_short_fr" expression=""/>
+        <default field="valve_type_short_en" expression=""/>
+        <default field="valve_type_short_ro" expression=""/>
+        <default field="valve_type_value_fr" expression=""/>
+        <default field="valve_type_value_en" expression=""/>
+        <default field="valve_type_value_ro" expression=""/>
+        <default field="valve_type_description_fr" expression=""/>
+        <default field="valve_type_description_en" expression=""/>
+        <default field="valve_type_description_ro" expression=""/>
+        <default field="valve_actuation_id" expression=""/>
+        <default field="valve_actuation_vl_active" expression=""/>
+        <default field="valve_actuation_short_fr" expression=""/>
+        <default field="valve_actuation_value_fr" expression=""/>
+        <default field="valve_actuation_description_fr" expression=""/>
+        <default field="valve_actuation_schema_visible" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_bedding20141219112927344</id>
@@ -42107,23 +42122,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -42196,6 +42197,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_cistern20130304110005061</id>
@@ -42220,23 +42235,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -42309,6 +42310,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_cover_type20141219115626290</id>
@@ -42331,23 +42346,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -42420,6 +42421,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_leak_cause20130822081237639</id>
@@ -42442,23 +42457,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -42531,6 +42532,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_overflow20130304170704046</id>
@@ -42555,23 +42570,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -42644,6 +42645,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_part_type20140429114640509</id>
@@ -42666,23 +42681,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -42768,6 +42769,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_pipe_function20130304110005186</id>
@@ -42792,26 +42807,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="schema_visible" expression=""/>
-        <default field="major" expression=""/>
-        <default field="code_sire" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -42896,6 +42894,23 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="schema_visible" expression=""/>
+        <default field="major" expression=""/>
+        <default field="code_sire" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_pipe_installmethod20130304110005209</id>
@@ -42920,23 +42935,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -43009,6 +43010,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_pipe_material20130304110005230</id>
@@ -43033,35 +43048,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression>_displayname_fr</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="_displayname_fr" expression=""/>
-        <default field="_displayname_en" expression=""/>
-        <default field="_displayname_ro" expression=""/>
-        <default field="diameter" expression=""/>
-        <default field="diameter_nominal" expression=""/>
-        <default field="diameter_internal" expression=""/>
-        <default field="diameter_external" expression=""/>
-        <default field="code_sire" expression=""/>
-        <default field="pressure_nominal" expression=""/>
-        <default field="sdr" expression=""/>
-        <default field="wall_thickness" expression=""/>
-        <default field="sn" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -43182,6 +43171,32 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="_displayname_fr" expression=""/>
+        <default field="_displayname_en" expression=""/>
+        <default field="_displayname_ro" expression=""/>
+        <default field="diameter" expression=""/>
+        <default field="diameter_nominal" expression=""/>
+        <default field="diameter_internal" expression=""/>
+        <default field="diameter_external" expression=""/>
+        <default field="code_sire" expression=""/>
+        <default field="pressure_nominal" expression=""/>
+        <default field="sdr" expression=""/>
+        <default field="wall_thickness" expression=""/>
+        <default field="sn" expression=""/>
+      </defaults>
+      <previewExpression>_displayname_fr</previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_pipe_protection20130304110005258</id>
@@ -43206,23 +43221,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -43295,6 +43296,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_precision20130304110011372</id>
@@ -43319,24 +43334,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="code_sire" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -43413,6 +43413,21 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="code_sire" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_precisionalti20131211161429510</id>
@@ -43435,24 +43450,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="code_sire" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -43529,6 +43529,21 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="code_sire" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_pumptype20130816140237776</id>
@@ -43551,24 +43566,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="code_sire" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -43645,6 +43645,21 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="code_sire" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_sourcequality20130820110518810</id>
@@ -43667,24 +43682,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="code_sire" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -43761,6 +43761,21 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="code_sire" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_sourcetype20130820110518791</id>
@@ -43783,24 +43798,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="code_sire" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -43877,6 +43877,21 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="code_sire" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_status20130304110011436</id>
@@ -43901,26 +43916,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="active" expression=""/>
-        <default field="functional" expression=""/>
-        <default field="code_sire" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -44020,6 +44018,23 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="active" expression=""/>
+        <default field="functional" expression=""/>
+        <default field="code_sire" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
     </maplayer>
     <maplayer minimumScale="0" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_subscriber_type20130304110011480</id>
@@ -44045,23 +44060,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserSelection" value="[]"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -44134,6 +44135,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_tank_firestorage20130304170704030</id>
@@ -44158,23 +44173,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -44247,6 +44248,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_valve_function20130304110011544</id>
@@ -44271,24 +44286,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="schema_visible" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -44365,6 +44365,21 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="schema_visible" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_valve_maintenance20130304110011567</id>
@@ -44389,24 +44404,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="priority" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -44483,6 +44483,21 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="priority" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_valve_type20130304110011685</id>
@@ -44507,23 +44522,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -44596,6 +44597,20 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE("id", '&lt;NULL>')</previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_visible20130304110011703</id>
@@ -44620,25 +44635,9 @@ def my_form_open(dialog, layer, feature):
         <property key="itemBrowserConnected" value="no"/>
       </customproperties>
       <provider encoding="ISO-8859-1">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="vl_code" expression=""/>
-        <default field="vl_code_int" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -44719,6 +44718,22 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="vl_code" expression=""/>
+        <default field="vl_code_int" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" readOnly="0" geometry="No geometry" type="vector" hasScaleBasedVisibilityFlag="0">
       <id>vl_watertype20131217141603877</id>
@@ -44741,24 +44756,9 @@ def my_form_open(dialog, layer, feature):
       </srs>
       <customproperties/>
       <provider encoding="System">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="vl_active" expression=""/>
-        <default field="short_fr" expression=""/>
-        <default field="short_en" expression=""/>
-        <default field="short_ro" expression=""/>
-        <default field="value_fr" expression=""/>
-        <default field="value_en" expression=""/>
-        <default field="value_ro" expression=""/>
-        <default field="description_fr" expression=""/>
-        <default field="description_en" expression=""/>
-        <default field="description_ro" expression=""/>
-        <default field="code_sire" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -44835,8 +44835,23 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="vl_active" expression=""/>
+        <default field="short_fr" expression=""/>
+        <default field="short_en" expression=""/>
+        <default field="short_ro" expression=""/>
+        <default field="value_fr" expression=""/>
+        <default field="value_en" expression=""/>
+        <default field="value_ro" expression=""/>
+        <default field="description_fr" expression=""/>
+        <default field="description_en" expression=""/>
+        <default field="description_ro" expression=""/>
+        <default field="code_sire" expression=""/>
+      </defaults>
+      <previewExpression></previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>513436.78827172500314191</xmin>
         <ymin>154882.74452505301451311</ymin>
@@ -44862,18 +44877,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="name" expression=""/>
-        <default field="population" expression=""/>
-        <default field="colorcode" expression=""/>
-        <default field="_sum_population" expression=""/>
-        <default field="_sum_subscriber" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -45330,8 +45336,17 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="name" expression=""/>
+        <default field="population" expression=""/>
+        <default field="colorcode" expression=""/>
+        <default field="_sum_population" expression=""/>
+        <default field="_sum_subscriber" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514611.88072958402335644</xmin>
         <ymin>157005.93633497500559315</ymin>
@@ -45357,50 +45372,9 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="_geometry_alt1_used" expression=""/>
-        <default field="_geometry_alt2_used" expression=""/>
-        <default field="_pipe_node_type" expression=""/>
-        <default field="_pipe_orientation" expression=""/>
-        <default field="_pipe_schema_visible" expression=""/>
-        <default field="geometry_alt1" expression=""/>
-        <default field="geometry_alt2" expression=""/>
-        <default field="update_geometry_alt1" expression=""/>
-        <default field="update_geometry_alt2" expression=""/>
-        <default field="identification" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_folder" expression=""/>
-        <default field="fk_locationtype" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_precisionalti" expression=""/>
-        <default field="fk_object_reference" expression=""/>
-        <default field="altitude" expression=""/>
-        <default field="year" expression=""/>
-        <default field="year_end" expression=""/>
-        <default field="orientation" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="schema_force_visible" expression=""/>
-        <default field="label_1_visible" expression=""/>
-        <default field="label_1_x" expression=""/>
-        <default field="label_1_y" expression=""/>
-        <default field="label_1_rotation" expression=""/>
-        <default field="label_1_text" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_x" expression=""/>
-        <default field="label_2_y" expression=""/>
-        <default field="label_2_rotation" expression=""/>
-        <default field="label_2_text" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -45720,6 +45694,7 @@ def my_form_open(dialog, layer, feature):
       <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
         <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
           <fontProperties description="Lato,10,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
         <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
           <layer pass="0" class="SimpleMarker" locked="0">
@@ -45859,57 +45834,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-    </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="100000" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-      <extent>
-        <xmin>537565.58635300002060831</xmin>
-        <ymin>153800.61718343000393361</ymin>
-        <xmax>537817.17765917000360787</xmax>
-        <ymax>155054.52909336000448093</ymax>
-      </extent>
-      <id>vw_node_installation20150918153835436</id>
-      <datasource>service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table="qwat_od"."vw_element_installation" (geometry) sql=</datasource>
-      <keywordList>
-        <value></value>
-      </keywordList>
-      <layername>ouvrage</layername>
-      <srs>
-        <spatialrefsys>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
-          <srsid>1919</srsid>
-          <srid>21781</srid>
-          <authid>EPSG:21781</authid>
-          <description>CH1903 / LV03</description>
-          <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
-          <geographicflag>false</geographicflag>
-        </spatialrefsys>
-      </srs>
-      <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>coalesce(identification|| ' ','') || CASE
-WHEN  "installation_type"  = 'chamber' THEN 'C. '
-WHEN "installation_type"  = 'pressurecontrol' AND fk_pressurecontrol_type = 2801 THEN 'CR. '
-WHEN  "installation_type"  = 'pressurecontrol' AND fk_pressurecontrol_type = 2802 THEN 'CCP. '
-WHEN  "installation_type"  = 'pressurecontrol' AND fk_pressurecontrol_type = 2803 THEN 'CRA. '
-WHEN  "installation_type"  = 'pump' THEN 'P. '
-WHEN  "installation_type"  = 'source' THEN 'S. '
-WHEN  "installation_type"  = 'tank' THEN 'R. '
-WHEN  "installation_type"  = 'treatment' THEN 'T. '
-ELSE ''
-END
-|| coalesce(name,'')</previewExpression>
-      <vectorjoins>
-        <join hasCustomPrefix="1" joinFieldName="id" customPrefix="status_" targetFieldName="fk_status" memoryCache="1" joinLayerId="vl_status20130304110011436">
-          <joinFieldsSubset>
-            <field name="active"/>
-            <field name="functional"/>
-          </joinFieldsSubset>
-        </join>
-      </vectorjoins>
-      <layerDependencies/>
-      <expressionfields>
-        <field typeName="int2" precision="0" expression="CASE WHEN  &quot;installation_type&quot; = 'chamber' THEN 'C.'&#xa; WHEN  &quot;installation_type&quot; =  'pressurecontrol'  AND  &quot;fk_pressurecontrol_type&quot; = 2801 THEN 'CR.'&#xa; WHEN  &quot;installation_type&quot; =  'pressurecontrol'  AND  &quot;fk_pressurecontrol_type&quot; = 2802 THEN 'CCP.'&#xa; WHEN  &quot;installation_type&quot; =  'pressurecontrol'  AND  &quot;fk_pressurecontrol_type&quot; = 2803 THEN 'CRA.'&#xa; WHEN  &quot;installation_type&quot; =  'pump'  THEN 'P.'&#xa; WHEN  &quot;installation_type&quot; =  'source'  THEN 'S.'&#xa; WHEN  &quot;installation_type&quot; =  'tank'  THEN 'R.'&#xa; WHEN  &quot;installation_type&quot; =  'treatment'  THEN 'T.'&#xa;ELSE ''&#xa;END" length="-1" type="2" comment="" name="_installation_type_short"/>
-      </expressionfields>
       <defaults>
         <default field="id" expression=""/>
         <default field="fk_district" expression=""/>
@@ -45949,71 +45873,47 @@ END
         <default field="label_2_y" expression=""/>
         <default field="label_2_rotation" expression=""/>
         <default field="label_2_text" expression=""/>
-        <default field="installation_type" expression=""/>
-        <default field="name" expression=""/>
-        <default field="fk_parent" expression=""/>
-        <default field="fk_remote" expression=""/>
-        <default field="fk_watertype" expression=""/>
-        <default field="parcel" expression=""/>
-        <default field="eca" expression=""/>
-        <default field="open_water_surface" expression=""/>
-        <default field="geometry_polygon" expression=""/>
-        <default field="fk_source_type" expression=""/>
-        <default field="fk_source_quality" expression=""/>
-        <default field="flow_lowest" expression=""/>
-        <default field="flow_average" expression=""/>
-        <default field="flow_concession" expression=""/>
-        <default field="contract_end" expression=""/>
-        <default field="gathering_chamber" expression=""/>
-        <default field="fk_pump_type" expression=""/>
-        <default field="fk_pipe_in" expression=""/>
-        <default field="fk_pipe_out" expression=""/>
-        <default field="fk_pump_operating" expression=""/>
-        <default field="no_pumps" expression=""/>
-        <default field="rejected_flow" expression=""/>
-        <default field="manometric_height" expression=""/>
-        <default field="fk_overflow" expression=""/>
-        <default field="fk_tank_firestorage" expression=""/>
-        <default field="storage_total" expression=""/>
-        <default field="storage_supply" expression=""/>
-        <default field="storage_fire" expression=""/>
-        <default field="altitude_overflow" expression=""/>
-        <default field="altitude_apron" expression=""/>
-        <default field="height_max" expression=""/>
-        <default field="fire_valve" expression=""/>
-        <default field="fire_remote" expression=""/>
-        <default field="_litrepercm" expression=""/>
-        <default field="cistern1_fk_type" expression=""/>
-        <default field="cistern1_dimension_1" expression=""/>
-        <default field="cistern1_dimension_2" expression=""/>
-        <default field="cistern1_storage" expression=""/>
-        <default field="_cistern1_litrepercm" expression=""/>
-        <default field="cistern2_fk_type" expression=""/>
-        <default field="cistern2_dimension_1" expression=""/>
-        <default field="cistern2_dimension_2" expression=""/>
-        <default field="cistern2_storage" expression=""/>
-        <default field="_cistern2_litrepercm" expression=""/>
-        <default field="sanitization_uv" expression=""/>
-        <default field="sanitization_chlorine_liquid" expression=""/>
-        <default field="sanitization_chlorine_gazeous" expression=""/>
-        <default field="sanitization_ozone" expression=""/>
-        <default field="filtration_membrane" expression=""/>
-        <default field="filtration_sandorgravel" expression=""/>
-        <default field="flocculation" expression=""/>
-        <default field="activatedcharcoal" expression=""/>
-        <default field="settling" expression=""/>
-        <default field="treatment_capacity" expression=""/>
-        <default field="networkseparation" expression=""/>
-        <default field="flow_meter" expression=""/>
-        <default field="water_meter" expression=""/>
-        <default field="manometer" expression=""/>
-        <default field="depth" expression=""/>
-        <default field="no_valves" expression=""/>
-        <default field="fk_pressurecontrol_type" expression=""/>
-        <default field="status_active" expression=""/>
-        <default field="status_functional" expression=""/>
-        <default field="_installation_type_short" expression=""/>
       </defaults>
+      <previewExpression></previewExpression>
+    </maplayer>
+    <maplayer simplifyAlgorithm="0" minimumScale="100000" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+      <extent>
+        <xmin>537565.58635300002060831</xmin>
+        <ymin>153800.61718343000393361</ymin>
+        <xmax>537817.17765917000360787</xmax>
+        <ymax>155054.52909336000448093</ymax>
+      </extent>
+      <id>vw_node_installation20150918153835436</id>
+      <datasource>service='qwat' sslmode=disable key='id' srid=21781 type=PointZ table="qwat_od"."vw_element_installation" (geometry) sql=</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>ouvrage</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
+          <srsid>1919</srsid>
+          <srid>21781</srid>
+          <authid>EPSG:21781</authid>
+          <description>CH1903 / LV03</description>
+          <projectionacronym>somerc</projectionacronym>
+          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <provider encoding="UTF-8">postgres</provider>
+      <vectorjoins>
+        <join hasCustomPrefix="1" joinFieldName="id" customPrefix="status_" targetFieldName="fk_status" memoryCache="1" joinLayerId="vl_status20130304110011436">
+          <joinFieldsSubset>
+            <field name="active"/>
+            <field name="functional"/>
+          </joinFieldsSubset>
+        </join>
+      </vectorjoins>
+      <layerDependencies/>
+      <expressionfields>
+        <field typeName="int2" precision="0" expression="CASE WHEN  &quot;installation_type&quot; = 'chamber' THEN 'C.'&#xa; WHEN  &quot;installation_type&quot; =  'pressurecontrol'  AND  &quot;fk_pressurecontrol_type&quot; = 2801 THEN 'CR.'&#xa; WHEN  &quot;installation_type&quot; =  'pressurecontrol'  AND  &quot;fk_pressurecontrol_type&quot; = 2802 THEN 'CCP.'&#xa; WHEN  &quot;installation_type&quot; =  'pressurecontrol'  AND  &quot;fk_pressurecontrol_type&quot; = 2803 THEN 'CRA.'&#xa; WHEN  &quot;installation_type&quot; =  'pump'  THEN 'P.'&#xa; WHEN  &quot;installation_type&quot; =  'source'  THEN 'S.'&#xa; WHEN  &quot;installation_type&quot; =  'tank'  THEN 'R.'&#xa; WHEN  &quot;installation_type&quot; =  'treatment'  THEN 'T.'&#xa;ELSE ''&#xa;END" length="-1" type="2" comment="" name="_installation_type_short"/>
+      </expressionfields>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -47731,8 +47631,124 @@ END
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="_geometry_alt1_used" expression=""/>
+        <default field="_geometry_alt2_used" expression=""/>
+        <default field="_pipe_node_type" expression=""/>
+        <default field="_pipe_orientation" expression=""/>
+        <default field="_pipe_schema_visible" expression=""/>
+        <default field="geometry_alt1" expression=""/>
+        <default field="geometry_alt2" expression=""/>
+        <default field="update_geometry_alt1" expression=""/>
+        <default field="update_geometry_alt2" expression=""/>
+        <default field="identification" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="fk_locationtype" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_precisionalti" expression=""/>
+        <default field="fk_object_reference" expression=""/>
+        <default field="altitude" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="orientation" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="label_1_visible" expression=""/>
+        <default field="label_1_x" expression=""/>
+        <default field="label_1_y" expression=""/>
+        <default field="label_1_rotation" expression=""/>
+        <default field="label_1_text" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_x" expression=""/>
+        <default field="label_2_y" expression=""/>
+        <default field="label_2_rotation" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="installation_type" expression=""/>
+        <default field="name" expression=""/>
+        <default field="fk_parent" expression=""/>
+        <default field="fk_remote" expression=""/>
+        <default field="fk_watertype" expression=""/>
+        <default field="parcel" expression=""/>
+        <default field="eca" expression=""/>
+        <default field="open_water_surface" expression=""/>
+        <default field="geometry_polygon" expression=""/>
+        <default field="fk_source_type" expression=""/>
+        <default field="fk_source_quality" expression=""/>
+        <default field="flow_lowest" expression=""/>
+        <default field="flow_average" expression=""/>
+        <default field="flow_concession" expression=""/>
+        <default field="contract_end" expression=""/>
+        <default field="gathering_chamber" expression=""/>
+        <default field="fk_pump_type" expression=""/>
+        <default field="fk_pipe_in" expression=""/>
+        <default field="fk_pipe_out" expression=""/>
+        <default field="fk_pump_operating" expression=""/>
+        <default field="no_pumps" expression=""/>
+        <default field="rejected_flow" expression=""/>
+        <default field="manometric_height" expression=""/>
+        <default field="fk_overflow" expression=""/>
+        <default field="fk_tank_firestorage" expression=""/>
+        <default field="storage_total" expression=""/>
+        <default field="storage_supply" expression=""/>
+        <default field="storage_fire" expression=""/>
+        <default field="altitude_overflow" expression=""/>
+        <default field="altitude_apron" expression=""/>
+        <default field="height_max" expression=""/>
+        <default field="fire_valve" expression=""/>
+        <default field="fire_remote" expression=""/>
+        <default field="_litrepercm" expression=""/>
+        <default field="cistern1_fk_type" expression=""/>
+        <default field="cistern1_dimension_1" expression=""/>
+        <default field="cistern1_dimension_2" expression=""/>
+        <default field="cistern1_storage" expression=""/>
+        <default field="_cistern1_litrepercm" expression=""/>
+        <default field="cistern2_fk_type" expression=""/>
+        <default field="cistern2_dimension_1" expression=""/>
+        <default field="cistern2_dimension_2" expression=""/>
+        <default field="cistern2_storage" expression=""/>
+        <default field="_cistern2_litrepercm" expression=""/>
+        <default field="sanitization_uv" expression=""/>
+        <default field="sanitization_chlorine_liquid" expression=""/>
+        <default field="sanitization_chlorine_gazeous" expression=""/>
+        <default field="sanitization_ozone" expression=""/>
+        <default field="filtration_membrane" expression=""/>
+        <default field="filtration_sandorgravel" expression=""/>
+        <default field="flocculation" expression=""/>
+        <default field="activatedcharcoal" expression=""/>
+        <default field="settling" expression=""/>
+        <default field="treatment_capacity" expression=""/>
+        <default field="networkseparation" expression=""/>
+        <default field="flow_meter" expression=""/>
+        <default field="water_meter" expression=""/>
+        <default field="manometer" expression=""/>
+        <default field="depth" expression=""/>
+        <default field="no_valves" expression=""/>
+        <default field="fk_pressurecontrol_type" expression=""/>
+        <default field="status_active" expression=""/>
+        <default field="status_functional" expression=""/>
+        <default field="_installation_type_short" expression=""/>
+      </defaults>
+      <previewExpression>coalesce(identification|| ' ','') || CASE
+WHEN  "installation_type"  = 'chamber' THEN 'C. '
+WHEN "installation_type"  = 'pressurecontrol' AND fk_pressurecontrol_type = 2801 THEN 'CR. '
+WHEN  "installation_type"  = 'pressurecontrol' AND fk_pressurecontrol_type = 2802 THEN 'CCP. '
+WHEN  "installation_type"  = 'pressurecontrol' AND fk_pressurecontrol_type = 2803 THEN 'CRA. '
+WHEN  "installation_type"  = 'pump' THEN 'P. '
+WHEN  "installation_type"  = 'source' THEN 'S. '
+WHEN  "installation_type"  = 'tank' THEN 'R. '
+WHEN  "installation_type"  = 'treatment' THEN 'T. '
+ELSE ''
+END
+|| coalesce(name,'')</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="100000" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="100000" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514025.66549615800613537</xmin>
         <ymin>155871.89602727998862974</ymin>
@@ -47744,7 +47760,7 @@ END
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>conduite impression 5000</layername>
+      <layername>conduites impression 5000</layername>
       <srs>
         <spatialrefsys>
           <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs</proj4>
@@ -47758,63 +47774,11 @@ END
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="pipe_material_" targetFieldName="fk_material" memoryCache="1" joinLayerId="vl_pipe_material20130304110005230"/>
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_function" expression=""/>
-        <default field="fk_installmethod" expression=""/>
-        <default field="fk_material" expression=""/>
-        <default field="fk_distributor" expression=""/>
-        <default field="fk_precision" expression=""/>
-        <default field="fk_protection" expression=""/>
-        <default field="fk_status" expression=""/>
-        <default field="fk_folder" expression=""/>
-        <default field="year" expression=""/>
-        <default field="year_end" expression=""/>
-        <default field="pressure_nominal" expression=""/>
-        <default field="remark" expression=""/>
-        <default field="fk_district" expression=""/>
-        <default field="fk_pressurezone" expression=""/>
-        <default field="fk_printmap" expression=""/>
-        <default field="_printmaps" expression=""/>
-        <default field="label_2_visible" expression=""/>
-        <default field="label_2_text" expression=""/>
-        <default field="_length2d" expression=""/>
-        <default field="_length3d" expression=""/>
-        <default field="number_of_pipe" expression=""/>
-        <default field="tunnel_or_bridge" expression=""/>
-        <default field="_valve_count" expression=""/>
-        <default field="_valve_closed" expression=""/>
-        <default field="_pressurezone" expression=""/>
-        <default field="_pressurezone_colorcode" expression=""/>
-        <default field="pipe_material_vl_active" expression=""/>
-        <default field="pipe_material_short_fr" expression=""/>
-        <default field="pipe_material_short_en" expression=""/>
-        <default field="pipe_material_short_ro" expression=""/>
-        <default field="pipe_material_value_fr" expression=""/>
-        <default field="pipe_material_value_en" expression=""/>
-        <default field="pipe_material_value_ro" expression=""/>
-        <default field="pipe_material_description_fr" expression=""/>
-        <default field="pipe_material_description_en" expression=""/>
-        <default field="pipe_material_description_ro" expression=""/>
-        <default field="pipe_material__displayname_fr" expression=""/>
-        <default field="pipe_material__displayname_en" expression=""/>
-        <default field="pipe_material__displayname_ro" expression=""/>
-        <default field="pipe_material_diameter" expression=""/>
-        <default field="pipe_material_diameter_nominal" expression=""/>
-        <default field="pipe_material_diameter_internal" expression=""/>
-        <default field="pipe_material_diameter_external" expression=""/>
-        <default field="pipe_material_code_sire" expression=""/>
-        <default field="pipe_material_pressure_nominal" expression=""/>
-        <default field="pipe_material_sdr" expression=""/>
-        <default field="pipe_material_wall_thickness" expression=""/>
-        <default field="pipe_material_sn" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -48491,8 +48455,60 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_function" expression=""/>
+        <default field="fk_installmethod" expression=""/>
+        <default field="fk_material" expression=""/>
+        <default field="fk_distributor" expression=""/>
+        <default field="fk_precision" expression=""/>
+        <default field="fk_protection" expression=""/>
+        <default field="fk_status" expression=""/>
+        <default field="fk_folder" expression=""/>
+        <default field="year" expression=""/>
+        <default field="year_end" expression=""/>
+        <default field="pressure_nominal" expression=""/>
+        <default field="remark" expression=""/>
+        <default field="fk_district" expression=""/>
+        <default field="fk_pressurezone" expression=""/>
+        <default field="fk_printmap" expression=""/>
+        <default field="_printmaps" expression=""/>
+        <default field="label_2_visible" expression=""/>
+        <default field="label_2_text" expression=""/>
+        <default field="_length2d" expression=""/>
+        <default field="_length3d" expression=""/>
+        <default field="number_of_pipe" expression=""/>
+        <default field="tunnel_or_bridge" expression=""/>
+        <default field="_valve_count" expression=""/>
+        <default field="_valve_closed" expression=""/>
+        <default field="_pressurezone" expression=""/>
+        <default field="_pressurezone_colorcode" expression=""/>
+        <default field="pipe_material_vl_active" expression=""/>
+        <default field="pipe_material_short_fr" expression=""/>
+        <default field="pipe_material_short_en" expression=""/>
+        <default field="pipe_material_short_ro" expression=""/>
+        <default field="pipe_material_value_fr" expression=""/>
+        <default field="pipe_material_value_en" expression=""/>
+        <default field="pipe_material_value_ro" expression=""/>
+        <default field="pipe_material_description_fr" expression=""/>
+        <default field="pipe_material_description_en" expression=""/>
+        <default field="pipe_material_description_ro" expression=""/>
+        <default field="pipe_material__displayname_fr" expression=""/>
+        <default field="pipe_material__displayname_en" expression=""/>
+        <default field="pipe_material__displayname_ro" expression=""/>
+        <default field="pipe_material_diameter" expression=""/>
+        <default field="pipe_material_diameter_nominal" expression=""/>
+        <default field="pipe_material_diameter_internal" expression=""/>
+        <default field="pipe_material_diameter_external" expression=""/>
+        <default field="pipe_material_code_sire" expression=""/>
+        <default field="pipe_material_pressure_nominal" expression=""/>
+        <default field="pipe_material_sdr" expression=""/>
+        <default field="pipe_material_wall_thickness" expression=""/>
+        <default field="pipe_material_sn" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" readOnly="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+    <maplayer simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" geometry="Line" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <extent>
         <xmin>514025.66549615800613537</xmin>
         <ymin>155871.89602727998862974</ymin>
@@ -48518,45 +48534,11 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <provider encoding="UTF-8">postgres</provider>
-      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
       <vectorjoins>
         <join hasCustomPrefix="1" joinFieldName="id" customPrefix="material_" targetFieldName="fk_material" memoryCache="1" joinLayerId="vl_pipe_material20130304110005230"/>
       </vectorjoins>
       <layerDependencies/>
       <expressionfields/>
-      <defaults>
-        <default field="id" expression=""/>
-        <default field="fk_parent" expression=""/>
-        <default field="fk_material" expression=""/>
-        <default field="_length2d" expression=""/>
-        <default field="_length3d" expression=""/>
-        <default field="tunnel_or_bridge" expression=""/>
-        <default field="schema_force_visible" expression=""/>
-        <default field="_valve_count" expression=""/>
-        <default field="_valve_closed" expression=""/>
-        <default field="material_vl_active" expression=""/>
-        <default field="material_short_fr" expression=""/>
-        <default field="material_short_en" expression=""/>
-        <default field="material_short_ro" expression=""/>
-        <default field="material_value_fr" expression=""/>
-        <default field="material_value_en" expression=""/>
-        <default field="material_value_ro" expression=""/>
-        <default field="material_description_fr" expression=""/>
-        <default field="material_description_en" expression=""/>
-        <default field="material_description_ro" expression=""/>
-        <default field="material__displayname_fr" expression=""/>
-        <default field="material__displayname_en" expression=""/>
-        <default field="material__displayname_ro" expression=""/>
-        <default field="material_diameter" expression=""/>
-        <default field="material_diameter_nominal" expression=""/>
-        <default field="material_diameter_internal" expression=""/>
-        <default field="material_diameter_external" expression=""/>
-        <default field="material_code_sire" expression=""/>
-        <default field="material_pressure_nominal" expression=""/>
-        <default field="material_sdr" expression=""/>
-        <default field="material_wall_thickness" expression=""/>
-        <default field="material_sn" expression=""/>
-      </defaults>
       <map-layer-style-manager current="">
         <map-layer-style name=""/>
       </map-layer-style-manager>
@@ -49124,6 +49106,40 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <defaults>
+        <default field="id" expression=""/>
+        <default field="fk_parent" expression=""/>
+        <default field="fk_material" expression=""/>
+        <default field="_length2d" expression=""/>
+        <default field="_length3d" expression=""/>
+        <default field="tunnel_or_bridge" expression=""/>
+        <default field="schema_force_visible" expression=""/>
+        <default field="_valve_count" expression=""/>
+        <default field="_valve_closed" expression=""/>
+        <default field="material_vl_active" expression=""/>
+        <default field="material_short_fr" expression=""/>
+        <default field="material_short_en" expression=""/>
+        <default field="material_short_ro" expression=""/>
+        <default field="material_value_fr" expression=""/>
+        <default field="material_value_en" expression=""/>
+        <default field="material_value_ro" expression=""/>
+        <default field="material_description_fr" expression=""/>
+        <default field="material_description_en" expression=""/>
+        <default field="material_description_ro" expression=""/>
+        <default field="material__displayname_fr" expression=""/>
+        <default field="material__displayname_en" expression=""/>
+        <default field="material__displayname_ro" expression=""/>
+        <default field="material_diameter" expression=""/>
+        <default field="material_diameter_nominal" expression=""/>
+        <default field="material_diameter_internal" expression=""/>
+        <default field="material_diameter_external" expression=""/>
+        <default field="material_code_sire" expression=""/>
+        <default field="material_pressure_nominal" expression=""/>
+        <default field="material_sdr" expression=""/>
+        <default field="material_wall_thickness" expression=""/>
+        <default field="material_sn" expression=""/>
+      </defaults>
+      <previewExpression>COALESCE( "id", '&lt;NULL>' )</previewExpression>
     </maplayer>
   </projectlayers>
   <properties>
@@ -50583,21 +50599,21 @@ def closeProject():
         <checked-legend-node id="{7c5fde76-05d7-4d4a-9eaa-953db28fbe87}"/>
         <checked-legend-node id="{013429dc-a1cd-4a17-904a-6550a0175046}"/>
         <checked-legend-node id="{1c3be22e-50cf-4ddb-a382-cb79acc30446}"/>
-        <checked-legend-node id="{2513a8b8-a110-4727-854c-6084f64e3bdf}"/>
         <checked-legend-node id="{2ce95337-6d17-4772-a67e-31f016923af4}"/>
-        <checked-legend-node id="{af5a1df4-2d61-4c6c-9951-0f6f900354d9}"/>
+        <checked-legend-node id="{2513a8b8-a110-4727-854c-6084f64e3bdf}"/>
         <checked-legend-node id="{6c5ec343-05d3-4fcd-8dc1-283232838086}"/>
+        <checked-legend-node id="{af5a1df4-2d61-4c6c-9951-0f6f900354d9}"/>
         <checked-legend-node id="{ab1fe7d1-2f11-4eea-915b-f4a08a217886}"/>
-        <checked-legend-node id="{75060a73-107d-4ace-bc35-d573de40488f}"/>
         <checked-legend-node id="{ca06b6f2-f1ee-4958-b79a-6cb6cbc2059b}"/>
+        <checked-legend-node id="{75060a73-107d-4ace-bc35-d573de40488f}"/>
         <checked-legend-node id="{e9048c41-9d67-475a-8909-a027412c34d1}"/>
         <checked-legend-node id="{7d0cfa7a-eaf4-499a-b977-1238b90ca15f}"/>
         <checked-legend-node id="{f550eef3-fdaa-427b-b415-bd7e8fc25f9e}"/>
         <checked-legend-node id="{d1bbbb53-b702-4d56-9f8b-ccf8029e5318}"/>
         <checked-legend-node id="{03ff9811-2539-4b32-b396-20796c2639bf}"/>
         <checked-legend-node id="{846076c3-b88b-4391-801a-578d0abcdaf9}"/>
-        <checked-legend-node id="{6f5c08e7-bf93-4eee-94df-3f749becb926}"/>
         <checked-legend-node id="{fb522923-eeee-47bb-8352-65a3d5637c4c}"/>
+        <checked-legend-node id="{6f5c08e7-bf93-4eee-94df-3f749becb926}"/>
         <checked-legend-node id="{684b69b2-b4e2-49e4-82f1-ea1e9a680e64}"/>
         <checked-legend-node id="{59ae2c57-00c7-4afe-bfba-16af06381694}"/>
         <checked-legend-node id="{1d54e4f9-8261-4fb7-ab45-581756bf08a2}"/>
@@ -50613,9 +50629,9 @@ def closeProject():
         <checked-legend-node id="{ad349920-d2f8-4ac3-ae12-639c93ed9224}"/>
         <checked-legend-node id="{835c4cad-787b-45b7-b242-516a4da8a7f7}"/>
         <checked-legend-node id="{9486a529-9a4e-4a3c-83fe-86f6f93102c0}"/>
+        <checked-legend-node id="{2e14d53a-6d2f-40b3-bf3b-4f32112e3d59}"/>
         <checked-legend-node id="{5b970fd5-5c37-4865-81a5-cab18c5fb58c}"/>
         <checked-legend-node id="{85a03431-ffdc-4bd4-9796-2113d60c4125}"/>
-        <checked-legend-node id="{2e14d53a-6d2f-40b3-bf3b-4f32112e3d59}"/>
         <checked-legend-node id="{46c7536a-ac7b-4e7b-afe6-33f9fee2f171}"/>
         <checked-legend-node id="{d0b9168b-e603-49dd-8c84-e17551131f81}"/>
         <checked-legend-node id="{1f73b079-4d8c-4982-b2ab-6e9b5756b800}"/>
@@ -50662,8 +50678,8 @@ def closeProject():
         <checked-legend-node id="{604665a8-506c-4fdf-a10d-1fa4e79706e9}"/>
         <checked-legend-node id="{c0076781-68f6-43ab-9b4b-1fb0a074b4c1}"/>
         <checked-legend-node id="{72c92aed-f674-478a-a8f8-e96348d0e09a}"/>
-        <checked-legend-node id="{467aeded-414e-4296-89ab-661c203802ce}"/>
         <checked-legend-node id="{b7cfa44a-acc1-4818-ae4e-eebc16b3b60f}"/>
+        <checked-legend-node id="{467aeded-414e-4296-89ab-661c203802ce}"/>
         <checked-legend-node id="{1748c4b8-9632-4c31-b4c6-1e750fbb851f}"/>
         <checked-legend-node id="{2af9d655-d60f-4ee2-a31b-d5f075a9fad8}"/>
         <checked-legend-node id="{cec9c0f1-7573-488d-917a-fb97f52e5cb2}"/>
@@ -50753,8 +50769,8 @@ def closeProject():
         <checked-legend-node id="{c0076781-68f6-43ab-9b4b-1fb0a074b4c1}"/>
         <checked-legend-node id="{ba47d809-a5d0-4192-b1ef-631a0c6a0fb2}"/>
         <checked-legend-node id="{8cf17e40-4159-47e8-b16b-e157021e9fd3}"/>
-        <checked-legend-node id="{17131e2c-6fc3-40b3-b53d-5bc039d78a6b}"/>
         <checked-legend-node id="{59878a6a-ca5c-4809-b1a0-b317151cfb27}"/>
+        <checked-legend-node id="{17131e2c-6fc3-40b3-b53d-5bc039d78a6b}"/>
         <checked-legend-node id="{18ded8b4-221b-4e2d-9817-0f52fd66b782}"/>
         <checked-legend-node id="{2aad166e-0cd1-4083-9002-8aead4f79917}"/>
         <checked-legend-node id="{ed82ce06-eee6-4f2d-833b-e537d0b18649}"/>
@@ -50762,8 +50778,8 @@ def closeProject():
         <checked-legend-node id="{d31d075b-227e-40b6-ab03-8d810a0d69b8}"/>
         <checked-legend-node id="{e946cc4f-cd0b-4ad9-8be4-7ffafae00622}"/>
         <checked-legend-node id="{9f3f6e03-b69a-427b-8367-e7d64d6fc557}"/>
-        <checked-legend-node id="{2af9d655-d60f-4ee2-a31b-d5f075a9fad8}"/>
         <checked-legend-node id="{6344ee42-45a2-40ee-b52d-f7b7db81a674}"/>
+        <checked-legend-node id="{2af9d655-d60f-4ee2-a31b-d5f075a9fad8}"/>
         <checked-legend-node id="{d1f57b66-0919-4b68-83e8-f078553bea81}"/>
         <checked-legend-node id="{72c92aed-f674-478a-a8f8-e96348d0e09a}"/>
         <checked-legend-node id="{bcc4a12d-4133-4556-adb8-a3cdedbd5406}"/>

--- a/qgis-project/qwat.qgs
+++ b/qgis-project/qwat.qgs
@@ -5,7 +5,7 @@
   <evaluateDefaultValues active="0"/>
   <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="">
     <customproperties/>
-    <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="Réseau">
+    <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="QWAT">
       <customproperties/>
       <layer-tree-group expanded="1" checked="Qt::PartiallyChecked" name="ouvrages">
         <customproperties/>
@@ -605,7 +605,7 @@
     </custom-order>
   </layer-tree-canvas>
   <legend updateDrawingOrder="false">
-    <legendgroup open="true" checked="Qt::PartiallyChecked" name="Réseau">
+    <legendgroup open="true" checked="Qt::PartiallyChecked" name="QWAT">
       <legendgroup open="true" checked="Qt::PartiallyChecked" name="ouvrages">
         <legendlayer drawingOrder="1" open="false" checked="Qt::Checked" name="ouvrage" showFeatureCount="1">
           <filegroup open="false" hidden="false">


### PR DESCRIPTION
At the moment there are two groups named ``Réseau``, one being the top one.
I think naming the top group to QWAT would be nice.
Moreover, duplicate groups/layers names are not directly supported by QGIS Server.

Furthermore, although the layer names are usually in plural form, there are some layers that are named at their singular form. Think it's better that we're consistent.

There's also the group ``Ouvrages`` with one of the two contained layers named ``ouvrage``.
Any suggestion here?

I realize that these are small changes but their absence is somehow not looking good.

What do you think?