### PR TITLE
Update pipe.ui

### DIFF
--- a/qgis-project/ui_forms/pipe.ui
+++ b/qgis-project/ui_forms/pipe.ui
@@ -395,7 +395,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="_districts">
+           <widget class="QLineEdit" name="fk_district">
             <property name="enabled">
              <bool>true</bool>
             </property>


### PR DESCRIPTION
Bad relation _district => fk_district

In hydrant.ui, that field is a combobox (not read only). Does it be the same ? 
In that case :
          <item row="1" column="1">
           <widget class="QComboBox" name="fk_district"/>
          </item>