### PR TITLE
Use the https protocol for data-model submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "data-model"]
 	path = data-model
-	url = git@github.com:qwat/qwat-data-model.git
+	url = https://github.com/qwat/qwat-data-model.git


### PR DESCRIPTION
This suggests fixing the "Readthedocs build" issue by using HTTPS rather that GIT for the data-model submodule. With HTTPS the Readthedocs build script should be able to fetch the data-model submodule.

Fixes #268